### PR TITLE
Packages pimp: Supports SF 2.7 and 3.0 upper and test for old versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,31 @@
 language: php
 
-php:
-  - 5.6
-  - 7.0
-  - hhvm
+matrix:
+  include:
+    - php: 5.6
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+    - php: 7.0
+      env: SYMFONY_VERSION='2.7.*'
+    - php: 7.0
+      env: SYMFONY_VERSION='2.8.*'
+    - php: 7.0
+      env: SYMFONY_VERSION='3.0.*'
+    - php: hhvm
+  allow_failures:
+    - php: hhvm
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache/files
+
+before_install:
+  - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
 
 install:
-  - composer self-update
-  - composer install --dev --prefer-source
+  - composer update $COMPOSER_FLAGS --prefer-source --optimize-autoloader
 
 before_script:
   - mkdir -p build/logs
@@ -21,7 +39,3 @@ after_script:
   - bash <(curl -s https://codecov.io/bash)
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml
-
-matrix:
-  allow_failures:
-    - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",
-        "squizlabs/php_codesniffer": "~2.0",
+        "squizlabs/php_codesniffer": "^2.4",
         "composer/composer": "~1.0-alpha"
     },
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,17 @@
     "require" : {
         "php" : ">=5.6",
         "php-di/php-di": "^5.0",
-        "symfony/process": "^2.7",
-        "symfony/filesystem": "^2.7",
+        "php-di/invoker": "^1.0",
+        "container-interop/container-interop": "^1.0",
+        "symfony/process": "^2.7|^3.0",
+        "symfony/filesystem": "^2.7|^3.0",
         "fzaninotto/faker": "^1.5",
         "aydin-hassan/cli-md-renderer": "~1.0",
         "php-school/psx": "~1.0",
         "php-school/cli-menu": "~1.0",
         "beberlei/assert": "^2.4",
         "psr/http-message": "^1.0",
-        "zendframework/zend-diactoros": "^1.1",
+        "zendframework/zend-diactoros": "^1.1.3",
         "myclabs/php-enum": "^1.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "277b7ad348c9bfc7cf06c2caa51114c4",
-    "content-hash": "5899a212f49e5ca3b28c58acbf3b53cd",
+    "hash": "46d18ca7e9cf909fea71bbe34aacc533",
+    "content-hash": "d5eb5ab30923660a4a03897104e1fb84",
     "packages": [
         {
             "name": "aydin-hassan/cli-md-renderer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "47b9ae5024c107ee05deedff79689999",
-    "content-hash": "6b3e919ceee622bd148d98e5af14d9d0",
+    "hash": "277b7ad348c9bfc7cf06c2caa51114c4",
+    "content-hash": "5899a212f49e5ca3b28c58acbf3b53cd",
     "packages": [
         {
             "name": "aydin-hassan/cli-md-renderer",
@@ -669,25 +669,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "637b64d0ee10f44ae98dbad651b1ecdf35a11e8c"
+                "reference": "064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/637b64d0ee10f44ae98dbad651b1ecdf35a11e8c",
-                "reference": "637b64d0ee10f44ae98dbad651b1ecdf35a11e8c",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f",
+                "reference": "064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -714,29 +714,29 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-13 10:28:07"
+            "time": "2016-01-27 11:34:55"
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac"
+                "reference": "dfecef47506179db2501430e732adbf3793099c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac",
-                "reference": "6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac",
+                "url": "https://api.github.com/repos/symfony/process/zipball/dfecef47506179db2501430e732adbf3793099c8",
+                "reference": "dfecef47506179db2501430e732adbf3793099c8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -763,7 +763,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-06 09:59:23"
+            "time": "2016-02-02 13:44:19"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -2285,16 +2285,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ebcdc507829df915f4ca23067bd59ee4ef61f6c3"
+                "reference": "5a02eaadaa285e2bb727eb6bbdfb8201fcd971b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ebcdc507829df915f4ca23067bd59ee4ef61f6c3",
-                "reference": "ebcdc507829df915f4ca23067bd59ee4ef61f6c3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5a02eaadaa285e2bb727eb6bbdfb8201fcd971b0",
+                "reference": "5a02eaadaa285e2bb727eb6bbdfb8201fcd971b0",
                 "shasum": ""
             },
             "require": {
@@ -2341,20 +2341,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-22 10:39:06"
+            "time": "2016-02-02 13:44:19"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8617895eb798b6bdb338321ce19453dc113e5675"
+                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8617895eb798b6bdb338321ce19453dc113e5675",
-                "reference": "8617895eb798b6bdb338321ce19453dc113e5675",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/623bda0abd9aa29e529c8e9c08b3b84171914723",
+                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723",
                 "shasum": ""
             },
             "require": {
@@ -2390,7 +2390,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-05 11:13:14"
+            "time": "2016-01-27 05:14:46"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2453,16 +2453,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "3df409958a646dad2bc5046c3fb671ee24a1a691"
+                "reference": "3cf0709d7fe936e97bee9e954382e449003f1d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3df409958a646dad2bc5046c3fb671ee24a1a691",
-                "reference": "3df409958a646dad2bc5046c3fb671ee24a1a691",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3cf0709d7fe936e97bee9e954382e449003f1d9a",
+                "reference": "3cf0709d7fe936e97bee9e954382e449003f1d9a",
                 "shasum": ""
             },
             "require": {
@@ -2498,7 +2498,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-26 13:39:53"
+            "time": "2016-02-02 13:44:19"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
### What has been done
- Symfony 3 is supported but was not configured in the right way at composer
- Travis:
  - Added prefer-lowest in order to test the minimum required libraries, I ended up finding out `zend-diactoros` <1.1.2 was failing then I upgraded to ^1.1.3
  - Also found out some problems with php-di version, that's why now invoker and container-interop are now declared on composer.json
  - The code is not compatible with phpcs <2.3
  - Pimped the matrix, now its testing under sf 2.7, 2.8 and 3.0 which are being used

You may be wondering, why composer update? Its the a way to test against multiple libraries versions, since the composer.lock is already safe you may want to test other possibilities, that's why I did it!

I hope it can be helpful, I did this because I was trying to install `learn-you-php` as global requirement but I had some versions conflicts!