### PR TITLE
Escape content to send to PHP

### DIFF
--- a/src/ExerciseRunner/CgiRunner.php
+++ b/src/ExerciseRunner/CgiRunner.php
@@ -156,7 +156,7 @@ class CgiRunner implements ExerciseRunnerInterface
         );
 
         $content                = $request->getBody()->__toString();
-        $cmd                    = sprintf('echo %s | %s', $content, $cgiBinary);
+        $cmd                    = sprintf('echo %s | %s', escapeshellarg($content), $cgiBinary);
         $env['CONTENT_LENGTH']  = $request->getBody()->getSize();
         $env['CONTENT_TYPE']    = $request->getHeaderLine('Content-Type');
 

--- a/test/ExerciseRunner/CgiRunnerTest.php
+++ b/test/ExerciseRunner/CgiRunnerTest.php
@@ -119,6 +119,30 @@ class CgiRunnerTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testVerifyReturnsSuccessIfPostSolutionOutputMatchesUserOutputWithMultipleParams()
+    {
+        $solution = SingleFileSolution::fromFile(__DIR__ . '/../res/cgi/post-multiple-solution.php');
+        $this->exercise
+            ->expects($this->once())
+            ->method('getSolution')
+            ->will($this->returnValue($solution));
+
+        $request = (new Request)
+            ->withMethod('POST')
+            ->withUri(new Uri('http://some.site'))
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+        $request->getBody()->write('number=5&start=4');
+
+        $this->exercise
+            ->expects($this->once())
+            ->method('getRequests')
+            ->will($this->returnValue([$request]));
+
+        $result = $this->runner->verify(realpath(__DIR__ . '/../res/cgi/post-multiple-solution.php'));
+        $this->assertInstanceOf(CgiOutResult::class, $result);
+    }
+
     public function testVerifyReturnsFailureIfUserSolutionFailsToExecute()
     {
         $solution = SingleFileSolution::fromFile(__DIR__ . '/../res/cgi/get-solution.php');

--- a/test/res/cgi/post-multiple-solution.php
+++ b/test/res/cgi/post-multiple-solution.php
@@ -1,0 +1,3 @@
+<?php
+
+echo $_POST['start'] + ($_POST['number'] * 2);


### PR DESCRIPTION
Multiple parameters in input data caused the PHP to not populate super globals as the `&` is interpreted by the shell. This patch escapes the content so it is passed as is to PHP.