### PR TITLE
Require nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "beberlei/assert": "^2.4",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1.3",
-        "myclabs/php-enum": "^1.4"
+        "myclabs/php-enum": "^1.4",
+        "nikic/php-parser": "^2.0"
     },
     "require-dev": {
         "composer/composer": "^1.0-alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5fef1157e3d0a05949d7fc08453cd264",
-    "content-hash": "a6a407c7673c5af84a174ab3baf2920b",
+    "hash": "c0a7e367e1769a8801bf28259ca35ba8",
+    "content-hash": "f87014b0689acde370e00077c2889bc5",
     "packages": [
         {
             "name": "aydin-hassan/cli-md-renderer",


### PR DESCRIPTION
We use `php-parser` but don't specifically require it, it was bought in by a third party package