### PR TITLE
Resolves #104: Simplify require checks - BC Break

### DIFF
--- a/src/Check/CodeParseCheck.php
+++ b/src/Check/CodeParseCheck.php
@@ -77,4 +77,13 @@ class CodeParseCheck implements SimpleCheckInterface
     {
         return ExerciseInterface::class;
     }
+
+    /**
+     *
+     * @return string
+     */
+    public function getPosition()
+    {
+        return SimpleCheckInterface::CHECK_BEFORE;
+    }
 }

--- a/src/Check/ComposerCheck.php
+++ b/src/Check/ComposerCheck.php
@@ -79,4 +79,13 @@ class ComposerCheck implements SimpleCheckInterface
     {
         return ComposerExerciseCheck::class;
     }
+
+    /**
+     *
+     * @return string
+     */
+    public function getPosition()
+    {
+        return SimpleCheckInterface::CHECK_BEFORE;
+    }
 }

--- a/src/Check/FileExistsCheck.php
+++ b/src/Check/FileExistsCheck.php
@@ -54,4 +54,13 @@ class FileExistsCheck implements SimpleCheckInterface
     {
         return ExerciseInterface::class;
     }
+
+    /**
+     *
+     * @return string
+     */
+    public function getPosition()
+    {
+        return SimpleCheckInterface::CHECK_BEFORE;
+    }
 }

--- a/src/Check/FunctionRequirementsCheck.php
+++ b/src/Check/FunctionRequirementsCheck.php
@@ -108,4 +108,13 @@ class FunctionRequirementsCheck implements SimpleCheckInterface
     {
         return FunctionRequirementsExerciseCheck::class;
     }
+
+    /**
+     *
+     * @return string
+     */
+    public function getPosition()
+    {
+        return SimpleCheckInterface::CHECK_AFTER;
+    }
 }

--- a/src/Check/PhpLintCheck.php
+++ b/src/Check/PhpLintCheck.php
@@ -58,4 +58,13 @@ class PhpLintCheck implements SimpleCheckInterface
     {
         return ExerciseInterface::class;
     }
+
+    /**
+     *
+     * @return string
+     */
+    public function getPosition()
+    {
+        return SimpleCheckInterface::CHECK_BEFORE;
+    }
 }

--- a/src/Check/SimpleCheckInterface.php
+++ b/src/Check/SimpleCheckInterface.php
@@ -14,6 +14,20 @@ use PhpSchool\PhpWorkshop\Result\ResultInterface;
 interface SimpleCheckInterface extends CheckInterface
 {
     /**
+     * Run this check before exercise verifying
+     *
+     * @return string
+     */
+    const CHECK_BEFORE = 'before';
+
+    /**
+     * Run this check after exercise verifying
+     *
+     * @return string
+     */
+    const CHECK_AFTER = 'after';
+
+    /**
      * Can this check run this exercise?
      *
      * @param ExerciseType $exerciseType
@@ -27,4 +41,11 @@ interface SimpleCheckInterface extends CheckInterface
      * @return ResultInterface
      */
     public function check(ExerciseInterface $exercise, $fileName);
+
+    /**
+     * either static::CHECK_BEFORE | static::CHECK_AFTER
+     *
+     * @return string
+     */
+    public function getPosition();
 }

--- a/test/Check/CodeParseCheckTest.php
+++ b/test/Check/CodeParseCheckTest.php
@@ -5,6 +5,7 @@ namespace PhpSchool\PhpWorkshopTest\Check;
 use PhpParser\ParserFactory;
 use PhpSchool\PhpWorkshop\Check\CheckInterface;
 use PhpSchool\PhpWorkshop\Check\CodeParseCheck;
+use PhpSchool\PhpWorkshop\Check\SimpleCheckInterface;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseInterface;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseType;
 use PhpSchool\PhpWorkshop\Result\Failure;
@@ -33,6 +34,7 @@ class CodeParseCheckTest extends PHPUnit_Framework_TestCase
         $this->check = new CodeParseCheck((new ParserFactory)->create(ParserFactory::PREFER_PHP7));
         $this->assertEquals('Code Parse Check', $this->check->getName());
         $this->assertEquals(ExerciseInterface::class, $this->check->getExerciseInterface());
+        $this->assertEquals(SimpleCheckInterface::CHECK_BEFORE, $this->check->getPosition());
 
         $this->assertTrue($this->check->canRun(ExerciseType::CGI()));
         $this->assertTrue($this->check->canRun(ExerciseType::CLI()));

--- a/test/Check/ComposerCheckTest.php
+++ b/test/Check/ComposerCheckTest.php
@@ -4,6 +4,7 @@ namespace PhpSchool\PhpWorkshopTest\Check;
 
 use InvalidArgumentException;
 use PhpSchool\PhpWorkshop\Check\ComposerCheck;
+use PhpSchool\PhpWorkshop\Check\SimpleCheckInterface;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseInterface;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseType;
 use PhpSchool\PhpWorkshop\ExerciseCheck\ComposerExerciseCheck;
@@ -35,6 +36,7 @@ class ComposerCheckTest extends PHPUnit_Framework_TestCase
         $this->exercise = new ComposerExercise;
         $this->assertEquals('Composer Dependency Check', $this->check->getName());
         $this->assertEquals(ComposerExerciseCheck::class, $this->check->getExerciseInterface());
+        $this->assertEquals(SimpleCheckInterface::CHECK_BEFORE, $this->check->getPosition());
 
         $this->assertTrue($this->check->canRun(ExerciseType::CGI()));
         $this->assertTrue($this->check->canRun(ExerciseType::CLI()));

--- a/test/Check/DatabaseCheckTest.php
+++ b/test/Check/DatabaseCheckTest.php
@@ -108,7 +108,7 @@ class DatabaseCheckTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('configure')
             ->will($this->returnCallback(function (ExerciseDispatcher $dispatcher) {
-                $dispatcher->requireListenableCheck(DatabaseCheck::class);
+                $dispatcher->requireCheck(DatabaseCheck::class);
             }));
 
         $this->exercise
@@ -148,7 +148,7 @@ class DatabaseCheckTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('configure')
             ->will($this->returnCallback(function (ExerciseDispatcher $dispatcher) {
-                $dispatcher->requireListenableCheck(DatabaseCheck::class);
+                $dispatcher->requireCheck(DatabaseCheck::class);
             }));
 
         $this->exercise
@@ -183,7 +183,7 @@ class DatabaseCheckTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('configure')
             ->will($this->returnCallback(function (ExerciseDispatcher $dispatcher) {
-                $dispatcher->requireListenableCheck(DatabaseCheck::class);
+                $dispatcher->requireCheck(DatabaseCheck::class);
             }));
 
         $results            = new ResultAggregator;
@@ -220,7 +220,7 @@ class DatabaseCheckTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('configure')
             ->will($this->returnCallback(function (ExerciseDispatcher $dispatcher) {
-                $dispatcher->requireListenableCheck(DatabaseCheck::class);
+                $dispatcher->requireCheck(DatabaseCheck::class);
             }));
 
         $this->exercise
@@ -264,7 +264,7 @@ class DatabaseCheckTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('configure')
             ->will($this->returnCallback(function (ExerciseDispatcher $dispatcher) {
-                $dispatcher->requireListenableCheck(DatabaseCheck::class);
+                $dispatcher->requireCheck(DatabaseCheck::class);
             }));
 
         $this->exercise

--- a/test/Check/FileExistsCheckTest.php
+++ b/test/Check/FileExistsCheckTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpSchool\PhpWorkshopTest\Check;
 
+use PhpSchool\PhpWorkshop\Check\SimpleCheckInterface;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseType;
 use PHPUnit_Framework_TestCase;
 use PhpSchool\PhpWorkshop\Check\FileExistsCheck;
@@ -39,6 +40,7 @@ class FileExistsCheckTest extends PHPUnit_Framework_TestCase
         $this->exercise = $this->getMock(ExerciseInterface::class);
         $this->assertEquals('File Exists Check', $this->check->getName());
         $this->assertEquals(ExerciseInterface::class, $this->check->getExerciseInterface());
+        $this->assertEquals(SimpleCheckInterface::CHECK_BEFORE, $this->check->getPosition());
 
         $this->assertTrue($this->check->canRun(ExerciseType::CGI()));
         $this->assertTrue($this->check->canRun(ExerciseType::CLI()));

--- a/test/Check/FunctionRequirementsCheckTest.php
+++ b/test/Check/FunctionRequirementsCheckTest.php
@@ -5,6 +5,7 @@ namespace PhpSchool\PhpWorkshopTest\Check;
 use InvalidArgumentException;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use PhpSchool\PhpWorkshop\Check\SimpleCheckInterface;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseType;
 use PhpSchool\PhpWorkshopTest\Asset\FunctionRequirementsExercise;
 use PHPUnit_Framework_TestCase;
@@ -45,6 +46,7 @@ class FunctionRequirementsCheckTest extends PHPUnit_Framework_TestCase
         $this->exercise = new FunctionRequirementsExercise;
         $this->assertEquals('Function Requirements Check', $this->check->getName());
         $this->assertEquals(FunctionRequirementsExerciseCheck::class, $this->check->getExerciseInterface());
+        $this->assertEquals(SimpleCheckInterface::CHECK_AFTER, $this->check->getPosition());
 
         $this->assertTrue($this->check->canRun(ExerciseType::CGI()));
         $this->assertTrue($this->check->canRun(ExerciseType::CLI()));

--- a/test/Check/PhpLintCheckTest.php
+++ b/test/Check/PhpLintCheckTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpSchool\PhpWorkshopTest\Check;
 
+use PhpSchool\PhpWorkshop\Check\SimpleCheckInterface;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseType;
 use PHPUnit_Framework_TestCase;
 use PhpSchool\PhpWorkshop\Check\PhpLintCheck;
@@ -33,6 +34,7 @@ class PhpLintCheckTest extends PHPUnit_Framework_TestCase
         $this->exercise = $this->getMock(ExerciseInterface::class);
         $this->assertEquals('PHP Code Check', $this->check->getName());
         $this->assertEquals(ExerciseInterface::class, $this->check->getExerciseInterface());
+        $this->assertEquals(SimpleCheckInterface::CHECK_BEFORE, $this->check->getPosition());
 
         $this->assertTrue($this->check->canRun(ExerciseType::CGI()));
         $this->assertTrue($this->check->canRun(ExerciseType::CLI()));


### PR DESCRIPTION
This is a BC break and will require major bump to 0.4. I found this to be quite complicated and probably unnecessary when writing the docs, having to specify the position.

Also two different methods to require a check was overly complex.

For a dev writing an exercise, it is nicer that requiring an exercise just consists of:

```php
$exerciseDispatcher->requireCheck(SomeSimpleCheck::class);
$exerciseDispatcher->requireCheck(SomeAdvancedCheck::class);
```

Instead of

```php
$exerciseDispatcher->requireCheck(SomeSimpleCheck::class, 'before');
$exerciseDispatcher->requireListenableCheck(SomeAdvancedCheck::class);
```

@mikeymike WDYT?