### PR TITLE
Check php-cgi --version on instantiation, and die with message if unable.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -166,6 +166,16 @@ final class Application
                     )
                 );
             return 1;
+        } catch(\RuntimeException $e) {
+            $container
+                ->get(OutputInterface::class)
+                ->printError(
+                    sprintf(
+                        '%s',
+                        $e->getMessage()
+                    )
+                );
+            return 1;
         }
         return $exitCode;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -166,7 +166,7 @@ final class Application
                     )
                 );
             return 1;
-        } catch(\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $container
                 ->get(OutputInterface::class)
                 ->printError(

--- a/src/ExerciseRunner/CgiRunner.php
+++ b/src/ExerciseRunner/CgiRunner.php
@@ -52,13 +52,17 @@ class CgiRunner implements ExerciseRunnerInterface
                 // Try one more time, relying on being in the php binary's directory (where it should be on Windows)
                 system(sprintf('%s --version %s', $newPath, $silence), $stillFailedToRun);
                 if ($stillFailedToRun) {
-                    throw new \RuntimeException('Could not load php-cgi binary. Please install php-cgi using your package manager.');
+                    throw new \RuntimeException(
+                        'Could not load php-cgi binary. Please install php-cgi using your package manager.'
+                    );
                 }
             }
         } else {
             @system('php-cgi --version > /dev/null 2>&1', $failedToRun);
             if ($failedToRun) {
-                throw new \RuntimeException('Could not load php-cgi binary. Please install php-cgi using your package manager.');
+                throw new \RuntimeException(
+                    'Could not load php-cgi binary. Please install php-cgi using your package manager.'
+                );
             }
         }
         $this->eventDispatcher = $eventDispatcher;

--- a/src/ExerciseRunner/CgiRunner.php
+++ b/src/ExerciseRunner/CgiRunner.php
@@ -43,6 +43,11 @@ class CgiRunner implements ExerciseRunnerInterface
      */
     public function __construct(CgiExercise $exercise, EventDispatcher $eventDispatcher)
     {
+        // Suppress shell output. Anything non-zero is a failure.
+        @system('php-cgi --version > /dev/null 2>&1', $failedToRun);
+        if ($failedToRun) {
+            die('Could not load php-cgi binary. Please install php-cgi using your package manager.' . PHP_EOL);
+        }
         $this->eventDispatcher = $eventDispatcher;
         $this->exercise = $exercise;
     }


### PR DESCRIPTION
This is a fairly quick and dirty solution to a complicated problem, so if it needs to be reworked that's fine. But this should at least result in users being given a helpful message should they miss getting the php-cgi binary installed and trying to verify problems that rely on it.

This is referenced in [issue #50](https://github.com/php-school/learn-you-php/issues/50)