### PR TITLE
BC BREAK: Preserve order of insertions and transformers

### DIFF
--- a/src/Patch.php
+++ b/src/Patch.php
@@ -12,14 +12,9 @@ use Closure;
 class Patch
 {
     /**
-     * @var CodeInsertion[]
-     */
-    private $insertions = [];
-
-    /**
      * @var array
      */
-    private $transformers = [];
+    private $modifications = [];
 
     /**
      * @param CodeInsertion $insertion
@@ -28,7 +23,7 @@ class Patch
     public function withInsertion(CodeInsertion $insertion)
     {
         $new = clone $this;
-        $new->insertions[] = $insertion;
+        $new->modifications[] = $insertion;
         return $new;
     }
 
@@ -39,23 +34,15 @@ class Patch
     public function withTransformer(Closure $closure)
     {
         $new = clone $this;
-        $new->transformers[] = $closure;
+        $new->modifications[] = $closure;
         return $new;
     }
 
     /**
      * @return array
      */
-    public function getInsertions()
+    public function getModifiers()
     {
-        return $this->insertions;
-    }
-
-    /**
-     * @return array
-     */
-    public function getTransformers()
-    {
-        return $this->transformers;
+        return $this->modifications;
     }
 }

--- a/test/PatchTest.php
+++ b/test/PatchTest.php
@@ -20,8 +20,8 @@ class PatchTest extends PHPUnit_Framework_TestCase
         $new = $patch->withInsertion($insertion);
         
         $this->assertNotSame($patch, $new);
-        $this->assertEmpty($patch->getInsertions());
-        $this->assertEquals([$insertion], $new->getInsertions());
+        $this->assertEmpty($patch->getModifiers());
+        $this->assertEquals([$insertion], $new->getModifiers());
     }
 
     public function testWithTransformer()
@@ -32,7 +32,7 @@ class PatchTest extends PHPUnit_Framework_TestCase
         };
         $new = $patch->withTransformer($transformer);
         $this->assertNotSame($patch, $new);
-        $this->assertEmpty($patch->getTransformers());
-        $this->assertEquals([$transformer], $new->getTransformers());
+        $this->assertEmpty($patch->getModifiers());
+        $this->assertEquals([$transformer], $new->getModifiers());
     }
 }


### PR DESCRIPTION
This is a BC break but it's weird behaviour.

If you add a transformer that wraps code in a `try/catch` then add a insertion which add a line of code at the top of the file, the inserted code would actually be placed inside the `try/catch`.

Since we are on 0.* releases we can break BC in `0.5`.

There's a few things I wanna fix so i'll leave this open until the others collect up.