### PR TITLE
Add a call to onSelected() when an exercise is selected from the menu

### DIFF
--- a/src/Exercise/AbstractExercise.php
+++ b/src/Exercise/AbstractExercise.php
@@ -25,6 +25,13 @@ abstract class AbstractExercise
     abstract public function getName();
 
     /**
+     * Allow to perform some action when an exercise is selected from the menu.
+     */
+    public function onSelected()
+    {
+    }
+
+    /**
      * This returns a single file solution named `solution.php` which
      * should exist in `workshop-root/exercises/<exercise-name>/solution/`.
      *

--- a/src/Exercise/ExerciseInterface.php
+++ b/src/Exercise/ExerciseInterface.php
@@ -67,4 +67,11 @@ interface ExerciseInterface
      * @return void
      */
     public function tearDown();
+
+    /**
+     * Allow to perform some action when an exercise is selected from the menu.
+     *
+     * @return void
+     */
+    public function onSelected();
 }

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -9,6 +9,8 @@ use PhpSchool\CliMenu\MenuItem\AsciiArtItem;
 use PhpSchool\PhpWorkshop\Command\CreditsCommand;
 use PhpSchool\PhpWorkshop\Command\HelpCommand;
 use PhpSchool\PhpWorkshop\Command\MenuCommandInvoker;
+use PhpSchool\PhpWorkshop\Event\Event;
+use PhpSchool\PhpWorkshop\Event\EventDispatcher;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseInterface;
 use PhpSchool\PhpWorkshop\ExerciseRenderer;
 use PhpSchool\PhpWorkshop\ExerciseRepository;
@@ -47,7 +49,10 @@ class MenuFactory
             ->addItems(array_map(function (ExerciseInterface $exercise) use ($exerciseRenderer, $userState) {
                 return [
                     $exercise->getName(),
-                    $exerciseRenderer,
+                    function (CliMenu $menu) use ($exerciseRenderer, $exercise) {
+                        $exercise->onSelected();
+                        $exerciseRenderer($menu);
+                    },
                     $userState->completedExercise($exercise->getName())
                 ];
             }, $exerciseRepository->findAll()))

--- a/test/Asset/ComposerExercise.php
+++ b/test/Asset/ComposerExercise.php
@@ -90,4 +90,14 @@ class ComposerExercise implements ExerciseInterface, ComposerExerciseCheck
     {
         $dispatcher->requireCheck(ComposerCheck::class);
     }
+
+    /**
+     * Allow to perform some action when an exercise is selected from the menu.
+     *
+     * @return void
+     */
+    public function onSelected()
+    {
+        // TODO: Implement onSelected() method.
+    }
 }

--- a/test/Asset/FunctionRequirementsExercise.php
+++ b/test/Asset/FunctionRequirementsExercise.php
@@ -106,4 +106,14 @@ class FunctionRequirementsExercise implements ExerciseInterface, FunctionRequire
     {
         return ['file'];
     }
+
+    /**
+     * Allow to perform some action when an exercise is selected from the menu.
+     *
+     * @return void
+     */
+    public function onSelected()
+    {
+        // TODO: Implement onSelected() method.
+    }
 }

--- a/test/Asset/PatchableExercise.php
+++ b/test/Asset/PatchableExercise.php
@@ -79,4 +79,14 @@ class PatchableExercise implements ExerciseInterface, SubmissionPatchable
     {
         // TODO: Implement configure() method.
     }
+
+    /**
+     * Allow to perform some action when an exercise is selected from the menu.
+     *
+     * @return void
+     */
+    public function onSelected()
+    {
+        // TODO: Implement onSelected() method.
+    }
 }


### PR DESCRIPTION
This is a BC break, hence targeting develop, it adds another method to `ExerciseInterface`, named `onSelect` which is invoked when an exercise is selected from the menu.

Partially fixes https://github.com/php-school/learn-you-php/issues/67
