### PR TITLE
Lazy container listeners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
 
 install:
-  - composer update $COMPOSER_FLAGS --prefer-source --optimize-autoloader
+  - composer update $COMPOSER_FLAGS --prefer-dist --optimize-autoloader
 
 before_script:
   - mkdir -p build/logs

--- a/app/config.php
+++ b/app/config.php
@@ -3,6 +3,7 @@
 use Colors\Color;
 use function DI\object;
 use function DI\factory;
+use function PhpSchool\PhpWorkshop\Event\containerListener;
 use Interop\Container\ContainerInterface;
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;
@@ -264,9 +265,38 @@ return [
         '@chris3ailey' => 'Chris Bailey'
     ],
     'appContributors' => [],
-    'eventListeners' => [
-        'route.pre.resolve.args' => [
-            CheckExerciseAssignedListener::class
+    'eventListeners'  => [
+        'check-exercise-assigned' => [
+            'route.pre.resolve.args' => [
+                containerListener(CheckExerciseAssignedListener::class)
+            ],
         ],
-    ]
+        'prepare-solution' => [
+            'verify.start' => [
+                containerListener(PrepareSolutionListener::class),
+            ],
+            'run.start' => [
+                containerListener(PrepareSolutionListener::class),
+            ],
+        ],
+        'code-patcher' => [
+            'run.start' => [
+                containerListener(CodePatchListener::class, 'patch'),
+            ],
+            'verify.pre.execute' => [
+                containerListener(CodePatchListener::class, 'patch'),
+            ],
+            'verify.post.execute' => [
+                containerListener(CodePatchListener::class, 'revert'),
+            ],
+            'run.finish' => [
+                containerListener(CodePatchListener::class, 'revert'),
+            ],
+        ],
+        'self-check' => [
+            'verify.post.check' => [
+                containerListener(SelfCheckListener::class)
+            ],
+        ],
+    ],
 ];

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,10 @@
     "autoload" : {
         "psr-4" : {
             "PhpSchool\\PhpWorkshop\\": "src"
-        }
+        },
+        "files": [
+            "src/Event/functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": { 

--- a/src/Event/ContainerListenerHelper.php
+++ b/src/Event/ContainerListenerHelper.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Event;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class ContainerListenerHelper
+{
+    /**
+     * @var string
+     */
+    private $service;
+
+    /**
+     * @var string
+     */
+    private $method;
+
+    /**
+     * @param $service
+     * @param string $method
+     */
+    public function __construct($service, $method = '__invoke')
+    {
+        $this->service = $service;
+        $this->method = $method;
+    }
+
+    /**
+     * @return string
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+}

--- a/src/Event/functions.php
+++ b/src/Event/functions.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Event;
+
+if (!function_exists('PhpSchool\PhpWorkshop\Event\containerListener')) {
+
+    /**
+     * @param string $service
+     * @param string $method
+     * @return ContainerListenerHelper
+     */
+    function containerListener($service, $method = '__invoke')
+    {
+        return new ContainerListenerHelper($service, $method);
+    }
+}

--- a/src/Factory/EventDispatcherFactory.php
+++ b/src/Factory/EventDispatcherFactory.php
@@ -4,11 +4,10 @@ namespace PhpSchool\PhpWorkshop\Factory;
 
 use Interop\Container\ContainerInterface;
 use PhpSchool\PhpWorkshop\Event\EventDispatcher;
+use PhpSchool\PhpWorkshop\Event\ContainerListenerHelper;
 use PhpSchool\PhpWorkshop\Exception\InvalidArgumentException;
-use PhpSchool\PhpWorkshop\Listener\CodePatchListener;
-use PhpSchool\PhpWorkshop\Listener\PrepareSolutionListener;
-use PhpSchool\PhpWorkshop\Listener\SelfCheckListener;
 use PhpSchool\PhpWorkshop\ResultAggregator;
+use PhpSchool\PhpWorkshop\Utils\Collection;
 
 /**
  * Class EventDispatcherFactory
@@ -27,34 +26,57 @@ class EventDispatcherFactory
     {
         $dispatcher = new EventDispatcher($container->get(ResultAggregator::class));
 
-        $prepareSolutionListener = $container->get(PrepareSolutionListener::class);
-        $dispatcher->listen('verify.start', $prepareSolutionListener);
-        $dispatcher->listen('run.start', $prepareSolutionListener);
-
-        $codePatcherListener = $container->get(CodePatchListener::class);
-        $dispatcher->listen('verify.pre.execute', [$codePatcherListener, 'patch']);
-        $dispatcher->listen('verify.post.execute', [$codePatcherListener, 'revert']);
-        $dispatcher->listen('run.start', [$codePatcherListener, 'patch']);
-        $dispatcher->listen('run.finish', [$codePatcherListener, 'revert']);
-
-        $dispatcher->listen('verify.post.check', $container->get(SelfCheckListener::class));
-
         //add listeners from config
         $eventListeners = $container->has('eventListeners') ? $container->get('eventListeners') : [];
 
         if (!is_array($eventListeners)) {
             throw InvalidArgumentException::typeMisMatch('array', $eventListeners);
         }
-        
-        array_walk($eventListeners, function ($listeners, $eventName) use ($dispatcher, $container) {
-            if (!is_array($listeners)) {
-                throw InvalidArgumentException::typeMisMatch('array', $listeners);
-            }
 
+        array_walk($eventListeners, function ($events) {
+            if (!is_array($events)) {
+                throw InvalidArgumentException::typeMisMatch('array', $events);
+            }
+        });
+
+        $eventListeners = $this->mergeListenerGroups($eventListeners);
+
+        array_walk($eventListeners, function ($listeners, $eventName) use ($dispatcher, $container) {
             $this->attachListeners($eventName, $listeners, $container, $dispatcher);
         });
 
         return $dispatcher;
+    }
+
+    /**
+     * @param array $listeners
+     * @return array
+     */
+    private function mergeListenerGroups(array $listeners)
+    {
+        $listeners = new Collection($listeners);
+
+        return $listeners
+            ->keys()
+            ->reduce(function (Collection $carry, $listenerGroup) use ($listeners) {
+                $events = new Collection($listeners->get($listenerGroup));
+
+                return $events
+                    ->keys()
+                    ->reduce(function (Collection $carry, $event) use ($events) {
+                        $listeners = $events->get($event);
+
+                        if (!is_array($listeners)) {
+                            throw InvalidArgumentException::typeMisMatch('array', $listeners);
+                        }
+
+                        return $carry->set(
+                            $event,
+                            array_merge($carry->get($event, []), $listeners)
+                        );
+                    }, $carry);
+            }, new Collection)
+            ->getArrayCopy();
     }
 
     /**
@@ -71,24 +93,30 @@ class EventDispatcherFactory
         EventDispatcher $dispatcher
     ) {
         array_walk($listeners, function ($listener) use ($eventName, $dispatcher, $container) {
-            if (is_callable($listener)) {
-                return $dispatcher->listen($eventName, $listener);
+            if ($listener instanceof ContainerListenerHelper) {
+                if (!$container->has($listener->getService())) {
+                    throw new InvalidArgumentException(
+                        sprintf('Container has no entry named: "%s"', $listener->getService())
+                    );
+                }
+
+                return $dispatcher->listen($eventName, function (...$args) use ($container, $listener) {
+                    $service = $container->get($listener->getService());
+
+                    if (!method_exists($service, $listener->getMethod())) {
+                        throw new InvalidArgumentException(
+                            sprintf('Method "%s" does not exist on "%s"', $listener->getMethod(), get_class($service))
+                        );
+                    }
+
+                    $service->{$listener->getMethod()}(...$args);
+                });
             }
 
-            if (!is_string($listener)) {
+            if (!is_callable($listener)) {
                 throw new InvalidArgumentException(
                     sprintf('Listener must be a callable or a container entry for a callable service.')
                 );
-            }
-
-            if (!$container->has($listener)) {
-                throw new InvalidArgumentException(sprintf('Container has no entry named: "%s"', $listener));
-            }
-
-            $listener = $container->get($listener);
-
-            if (!is_callable($listener)) {
-                throw InvalidArgumentException::typeMisMatch('callable', $listener);
             }
 
             return $dispatcher->listen($eventName, $listener);

--- a/src/Utils/ArrayObject.php
+++ b/src/Utils/ArrayObject.php
@@ -25,7 +25,7 @@ class ArrayObject implements IteratorAggregate, Countable
      *
      * @param array $array
      */
-    public function __construct(array $array)
+    public function __construct(array $array = [])
     {
         $this->array = $array;
     }
@@ -40,6 +40,59 @@ class ArrayObject implements IteratorAggregate, Countable
     public function map(callable $callback)
     {
         return new static (array_map($callback, $this->array));
+    }
+
+    /**
+     * Run a callable over each item in the array and flatten the results by one level returning a new instance of
+     * `ArrayObject` with the flattened items.
+     *
+     * @param callable $callback
+     * @return static
+     */
+    public function flatMap(callable $callback)
+    {
+        return $this->map($callback)->collapse();
+    }
+
+    /**
+     * Collapse an array of arrays into a single array returning a new instance of `ArrayObject`
+     * with the collapsed items.
+     *
+     * @return static
+     */
+    public function collapse()
+    {
+        $results = [];
+
+        foreach ($this->array as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $results = array_merge($results, $item);
+        }
+
+        return new static($results);
+    }
+
+    /**
+     * Reduce the items to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed     $initial
+     * @return mixed
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        return array_reduce($this->array, $callback, $initial);
+    }
+
+    /**
+     * @return static
+     */
+    public function keys()
+    {
+        return new static(array_keys($this->array));
     }
 
     /**
@@ -73,6 +126,36 @@ class ArrayObject implements IteratorAggregate, Countable
     public function append($value)
     {
         return new static(array_merge($this->array, [$value]));
+    }
+
+    /**
+     * Get an item at the given key.
+     *
+     * @param mixed $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if (isset($this->array[$key])) {
+            return $this->array[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * Set the item at a given offset and return a new instance.
+     *
+     * @param mixed $key
+     * @param mixed $value
+     * @return static
+     */
+    public function set($key, $value)
+    {
+        $items = $this->array;
+        $items[$key] = $value;
+        return new static($items);
     }
 
     /**

--- a/src/Utils/Collection.php
+++ b/src/Utils/Collection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Utils;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class Collection extends ArrayObject
+{
+
+}

--- a/test/Event/ContainerListenerHelperTest.php
+++ b/test/Event/ContainerListenerHelperTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpSchool\PhpWorkshopTest\Event;
+
+use PhpSchool\PhpWorkshop\Event\ContainerListenerHelper;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class ContainerListenerHelperTest extends PHPUnit_Framework_TestCase
+{
+    public function testDefaultMethodIsInvoke()
+    {
+        $helper = new ContainerListenerHelper('Some\Object');
+
+        $this->assertEquals('Some\Object', $helper->getService());
+        $this->assertEquals('__invoke', $helper->getMethod());
+    }
+
+    public function testWithCustomMethod()
+    {
+        $helper = new ContainerListenerHelper('Some\Object', 'myMethod');
+
+        $this->assertEquals('Some\Object', $helper->getService());
+        $this->assertEquals('myMethod', $helper->getMethod());
+    }
+}

--- a/test/Factory/EventDispatcherFactoryTest.php
+++ b/test/Factory/EventDispatcherFactoryTest.php
@@ -2,13 +2,13 @@
 
 namespace PhpSchool\PhpWorkshopTest\Factory;
 
+use DI\ContainerBuilder;
+use PhpSchool\PhpWorkshop\Event\Event;
+use function PhpSchool\PhpWorkshop\Event\containerListener;
 use Interop\Container\ContainerInterface;
 use PhpSchool\PhpWorkshop\Event\EventDispatcher;
 use PhpSchool\PhpWorkshop\Exception\InvalidArgumentException;
 use PhpSchool\PhpWorkshop\Factory\EventDispatcherFactory;
-use PhpSchool\PhpWorkshop\Listener\CodePatchListener;
-use PhpSchool\PhpWorkshop\Listener\PrepareSolutionListener;
-use PhpSchool\PhpWorkshop\Listener\SelfCheckListener;
 use PhpSchool\PhpWorkshop\ResultAggregator;
 use PHPUnit_Framework_TestCase;
 
@@ -20,7 +20,7 @@ use PHPUnit_Framework_TestCase;
 class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
 {
 
-    public function testCreate()
+    public function testCreateWithNoConfig()
     {
         $c = $this->createMock(ContainerInterface::class);
 
@@ -28,57 +28,13 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
             ->method('get')
             ->with(ResultAggregator::class)
             ->will($this->returnValue(new ResultAggregator));
-
-        $prepareSolutionListener = new PrepareSolutionListener;
-
-        $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
 
         $dispatcher = (new EventDispatcherFactory)->__invoke($c);
         $this->assertInstanceOf(EventDispatcher::class, $dispatcher);
-        $this->assertSame(
-            [
-                'verify.start' => [
-                    $prepareSolutionListener
-                ],
-                'run.start' => [
-                    $prepareSolutionListener,
-                    [$codePatchListener, 'patch'],
-                ],
-                'verify.pre.execute' => [
-                    [$codePatchListener, 'patch'],
-                ],
-                'verify.post.execute' => [
-                    [$codePatchListener, 'revert'],
-                ],
-                'run.finish' => [
-                    [$codePatchListener, 'revert'],
-                ],
-                'verify.post.check' => [
-                    $selfCheckListener
-                ]
-            ],
-            $this->readAttribute($dispatcher, 'listeners')
-        );
+        $this->assertSame([], $this->readAttribute($dispatcher, 'listeners'));
     }
 
-    public function testConfigEventListenersThrowsExceptionIfEventsNotArray()
+    public function testExceptionIsThrownIfEventListenerGroupsNotArray()
     {
         $c = $this->createMock(ContainerInterface::class);
 
@@ -87,33 +43,12 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
             ->with(ResultAggregator::class)
             ->will($this->returnValue(new ResultAggregator));
 
-        $prepareSolutionListener = new PrepareSolutionListener;
-
         $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
-
-        $c->expects($this->at(4))
             ->method('has')
             ->with('eventListeners')
             ->willReturn(true);
 
-        $c->expects($this->at(5))
+        $c->expects($this->at(2))
             ->method('get')
             ->with('eventListeners')
             ->will($this->returnValue(new \stdClass));
@@ -124,7 +59,7 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
         (new EventDispatcherFactory)->__invoke($c);
     }
 
-    public function testConfigEventListenersThrowsExceptionIfEventsListenersNotArray()
+    public function testExceptionIsThrownIfEventsNotArray()
     {
         $c = $this->createMock(ContainerInterface::class);
 
@@ -133,36 +68,15 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
             ->with(ResultAggregator::class)
             ->will($this->returnValue(new ResultAggregator));
 
-        $prepareSolutionListener = new PrepareSolutionListener;
-
         $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
-
-        $c->expects($this->at(4))
             ->method('has')
             ->with('eventListeners')
             ->willReturn(true);
 
-        $c->expects($this->at(5))
+        $c->expects($this->at(2))
             ->method('get')
             ->with('eventListeners')
-            ->will($this->returnValue([ 'someEvent' => new \stdClass]));
+            ->will($this->returnValue(['my-group' => new \stdClass]));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected: "array" Received: "stdClass"');
@@ -170,7 +84,7 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
         (new EventDispatcherFactory)->__invoke($c);
     }
 
-    public function testConfigEventListenersThrowsExceptionIfEventsListenerNotCallableOrString()
+    public function testExceptionIsThrownIfEventListenersNotArray()
     {
         $c = $this->createMock(ContainerInterface::class);
 
@@ -179,36 +93,48 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
             ->with(ResultAggregator::class)
             ->will($this->returnValue(new ResultAggregator));
 
-        $prepareSolutionListener = new PrepareSolutionListener;
-
         $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
-
-        $c->expects($this->at(4))
             ->method('has')
             ->with('eventListeners')
             ->willReturn(true);
 
-        $c->expects($this->at(5))
+        $c->expects($this->at(2))
             ->method('get')
             ->with('eventListeners')
-            ->will($this->returnValue([ 'someEvent' => [new \stdClass]]));
+            ->will($this->returnValue([
+                'my-group' => [
+                    'someEvent' => new \stdClass
+                ]
+            ]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected: "array" Received: "stdClass"');
+
+        (new EventDispatcherFactory)->__invoke($c);
+    }
+
+    public function testExceptionIsThrownIfListenerNotCallable()
+    {
+        $c = $this->createMock(ContainerInterface::class);
+
+        $c->expects($this->at(0))
+            ->method('get')
+            ->with(ResultAggregator::class)
+            ->will($this->returnValue(new ResultAggregator));
+
+        $c->expects($this->at(1))
+            ->method('has')
+            ->with('eventListeners')
+            ->willReturn(true);
+
+        $c->expects($this->at(2))
+            ->method('get')
+            ->with('eventListeners')
+            ->will($this->returnValue([
+                'my-group' => [
+                    'someEvent' => [new \stdClass]
+                ]
+            ]));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Listener must be a callable or a container entry for a callable service.');
@@ -216,7 +142,7 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
         (new EventDispatcherFactory)->__invoke($c);
     }
 
-    public function testConfigEventListenersThrowsExceptionIfEventsListenerContainerEntryNotExist()
+    public function testExceptionIsThrownIfEventsListenerContainerEntryNotExist()
     {
         $c = $this->createMock(ContainerInterface::class);
 
@@ -225,100 +151,27 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
             ->with(ResultAggregator::class)
             ->will($this->returnValue(new ResultAggregator));
 
-        $prepareSolutionListener = new PrepareSolutionListener;
-
         $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
-
-        $c->expects($this->at(4))
             ->method('has')
             ->with('eventListeners')
             ->willReturn(true);
 
-        $c->expects($this->at(5))
+        $c->expects($this->at(2))
             ->method('get')
             ->with('eventListeners')
-            ->will($this->returnValue([ 'someEvent' => ['nonExistingContainerEntry']]));
+            ->will($this->returnValue([
+                'my-group' => [
+                    'someEvent' => [containerListener('nonExistingContainerEntry')]
+                ]
+            ]));
 
-        $c->expects($this->at(6))
+        $c->expects($this->at(3))
             ->method('has')
             ->with('nonExistingContainerEntry')
             ->will($this->returnValue(false));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Container has no entry named: "nonExistingContainerEntry"');
-
-        (new EventDispatcherFactory)->__invoke($c);
-    }
-
-    public function testConfigEventListenersThrowsExceptionIfEventsListenerContainerEntryNotCallable()
-    {
-        $c = $this->createMock(ContainerInterface::class);
-
-        $c->expects($this->at(0))
-            ->method('get')
-            ->with(ResultAggregator::class)
-            ->will($this->returnValue(new ResultAggregator));
-
-        $prepareSolutionListener = new PrepareSolutionListener;
-
-        $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
-
-        $c->expects($this->at(4))
-            ->method('has')
-            ->with('eventListeners')
-            ->willReturn(true);
-
-        $c->expects($this->at(5))
-            ->method('get')
-            ->with('eventListeners')
-            ->will($this->returnValue([ 'someEvent' => ['notCallableEntry']]));
-
-        $c->expects($this->at(6))
-            ->method('has')
-            ->with('notCallableEntry')
-            ->will($this->returnValue(true));
-
-        $c->expects($this->at(7))
-            ->method('get')
-            ->with('notCallableEntry')
-            ->will($this->returnValue(null));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected: "callable" Received: "NULL"');
 
         (new EventDispatcherFactory)->__invoke($c);
     }
@@ -332,63 +185,27 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
             ->with(ResultAggregator::class)
             ->will($this->returnValue(new ResultAggregator));
 
-        $prepareSolutionListener = new PrepareSolutionListener;
-
-        $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
-
         $callback = function () {
         };
 
-        $c->expects($this->at(4))
+        $c->expects($this->at(1))
             ->method('has')
             ->with('eventListeners')
             ->willReturn(true);
 
-        $c->expects($this->at(5))
+        $c->expects($this->at(2))
             ->method('get')
             ->with('eventListeners')
-            ->will($this->returnValue([ 'someEvent' => [$callback]]));
+            ->will($this->returnValue([
+                'my-group' => [
+                    'someEvent' => [$callback]
+                ]
+            ]));
 
         $dispatcher = (new EventDispatcherFactory)->__invoke($c);
         $this->assertInstanceOf(EventDispatcher::class, $dispatcher);
         $this->assertSame(
             [
-                'verify.start' => [
-                    $prepareSolutionListener
-                ],
-                'run.start' => [
-                    $prepareSolutionListener,
-                    [$codePatchListener, 'patch'],
-                ],
-                'verify.pre.execute' => [
-                    [$codePatchListener, 'patch'],
-                ],
-                'verify.post.execute' => [
-                    [$codePatchListener, 'revert'],
-                ],
-                'run.finish' => [
-                    [$codePatchListener, 'revert'],
-                ],
-                'verify.post.check' => [
-                    $selfCheckListener
-                ],
                 'someEvent' => [
                     $callback
                 ]
@@ -397,87 +214,88 @@ class EventDispatcherFactoryTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testConfigEventListenersWithContainerEntry()
+    public function testListenerFromContainerIsNotFetchedDuringAttaching()
     {
-        $c = $this->createMock(ContainerInterface::class);
+        $c = $this->prophesize(ContainerInterface::class);
 
-        $c->expects($this->at(0))
-            ->method('get')
-            ->with(ResultAggregator::class)
-            ->will($this->returnValue(new ResultAggregator));
+        $c->get(ResultAggregator::class)->willReturn(new ResultAggregator);
+        $c->has('eventListeners')->willReturn(true);
+        $c->get('eventListeners')->willReturn([
+            'my-group' => [
+                'someEvent' => [containerListener('containerEntry')]
+            ]
+        ]);
+        $c->has('containerEntry')->willReturn(true);
 
-        $prepareSolutionListener = new PrepareSolutionListener;
 
-        $c->expects($this->at(1))
-            ->method('get')
-            ->with(PrepareSolutionListener::class)
-            ->will($this->returnValue($prepareSolutionListener));
-
-        $codePatchListener = $this->createMock(CodePatchListener::class);
-
-        $c->expects($this->at(2))
-            ->method('get')
-            ->with(CodePatchListener::class)
-            ->will($this->returnValue($codePatchListener));
-
-        $selfCheckListener = new SelfCheckListener(new ResultAggregator);
-
-        $c->expects($this->at(3))
-            ->method('get')
-            ->with(SelfCheckListener::class)
-            ->will($this->returnValue($selfCheckListener));
-
-        $c->expects($this->at(4))
-            ->method('has')
-            ->with('eventListeners')
-            ->willReturn(true);
-
-        $c->expects($this->at(5))
-            ->method('get')
-            ->with('eventListeners')
-            ->will($this->returnValue([ 'someEvent' => ['containerEntry']]));
-
-        $c->expects($this->at(6))
-            ->method('has')
-            ->with('containerEntry')
-            ->will($this->returnValue(true));
-
-        $callback = function () {
-        };
-
-        $c->expects($this->at(7))
-            ->method('get')
-            ->with('containerEntry')
-            ->will($this->returnValue($callback));
-
-        $dispatcher = (new EventDispatcherFactory)->__invoke($c);
+        $dispatcher = (new EventDispatcherFactory)->__invoke($c->reveal());
         $this->assertInstanceOf(EventDispatcher::class, $dispatcher);
-        $this->assertSame(
-            [
-                'verify.start' => [
-                    $prepareSolutionListener
-                ],
-                'run.start' => [
-                    $prepareSolutionListener,
-                    [$codePatchListener, 'patch'],
-                ],
-                'verify.pre.execute' => [
-                    [$codePatchListener, 'patch'],
-                ],
-                'verify.post.execute' => [
-                    [$codePatchListener, 'revert'],
-                ],
-                'run.finish' => [
-                    [$codePatchListener, 'revert'],
-                ],
-                'verify.post.check' => [
-                    $selfCheckListener
-                ],
-                'someEvent' => [
-                    $callback
-                ]
-            ],
-            $this->readAttribute($dispatcher, 'listeners')
-        );
+        $this->assertArrayHasKey('someEvent', $this->readAttribute($dispatcher, 'listeners'));
+
+        $c->get('containerEntry')->shouldNotHaveBeenCalled();
+    }
+
+    public function testListenerFromContainerIsFetchedWhenEventDispatched()
+    {
+        $c = $this->prophesize(ContainerInterface::class);
+
+        $c->get(ResultAggregator::class)->willReturn(new ResultAggregator);
+        $c->has('eventListeners')->willReturn(true);
+        $c->get('eventListeners')->willReturn([
+            'my-group' => [
+                'someEvent' => [containerListener('containerEntry')]
+            ]
+        ]);
+        $c->has('containerEntry')->willReturn(true);
+        $c->get('containerEntry')->willReturn(function () {
+        });
+
+        $dispatcher = (new EventDispatcherFactory)->__invoke($c->reveal());
+        $this->assertInstanceOf(EventDispatcher::class, $dispatcher);
+        $this->assertArrayHasKey('someEvent', $this->readAttribute($dispatcher, 'listeners'));
+
+        $dispatcher->dispatch(new Event('someEvent'));
+    }
+
+    public function testExceptionIsThrownIfMethodDoesNotExistOnContainerEntry()
+    {
+        $c = $this->prophesize(ContainerInterface::class);
+
+        $c->get(ResultAggregator::class)->willReturn(new ResultAggregator);
+        $c->has('eventListeners')->willReturn(true);
+        $c->get('eventListeners')->willReturn([
+            'my-group' => [
+                'someEvent' => [containerListener('containerEntry', 'notHere')]
+            ]
+        ]);
+        $c->has('containerEntry')->willReturn(true);
+        $c->get('containerEntry')->willReturn(new \stdClass);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Method "notHere" does not exist on "stdClass"');
+
+        $dispatcher = (new EventDispatcherFactory)->__invoke($c->reveal());
+        $this->assertInstanceOf(EventDispatcher::class, $dispatcher);
+
+        $dispatcher->dispatch(new Event('someEvent'));
+    }
+
+    public function testDefaultListenersAreRegisteredFromConfig()
+    {
+        $containerBuilder = new ContainerBuilder;
+        $containerBuilder->addDefinitions(__DIR__ . '/../../app/config.php');
+
+        $container = $containerBuilder->build();
+
+        $dispatcher = (new EventDispatcherFactory)->__invoke($container);
+
+        $listeners = $this->readAttribute($dispatcher, 'listeners');
+
+        $this->assertArrayHasKey('verify.start', $listeners);
+        $this->assertArrayHasKey('run.start', $listeners);
+        $this->assertArrayHasKey('verify.pre.execute', $listeners);
+        $this->assertArrayHasKey('verify.post.execute', $listeners);
+        $this->assertArrayHasKey('run.finish', $listeners);
+        $this->assertArrayHasKey('verify.post.check', $listeners);
     }
 }

--- a/test/Util/ArrayObjectTest.php
+++ b/test/Util/ArrayObjectTest.php
@@ -58,4 +58,76 @@ class ArrayObjectTest extends PHPUnit_Framework_TestCase
         $arrayObject = new ArrayObject([1, 2, 3]);
         $this->assertSame([1, 2, 3], $arrayObject->getArrayCopy());
     }
+
+    public function testFlatMap()
+    {
+        $arrayObject = new ArrayObject([
+            ['name' => 'Aydin', 'pets' => ['rat', 'raccoon', 'binturong']],
+            ['name' => 'Caroline', 'pets' => ['rabbit', 'squirrel', 'dog']],
+        ]);
+        $new = $arrayObject->flatMap(function (array $item) {
+            return $item['pets'];
+        });
+
+        $this->assertSame(['rat', 'raccoon', 'binturong', 'rabbit', 'squirrel', 'dog'], $new->getArrayCopy());
+    }
+
+    public function testCollapse()
+    {
+        $arrayObject = new ArrayObject([[1, 2], [3, 4, 5], [6, 7, 8]]);
+        $new = $arrayObject->collapse();
+
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8], $new->getArrayCopy());
+
+        //with non array elements (should be skipped)
+        $arrayObject = new ArrayObject([[1, 2], [3, 4, 5], [6, 7, 8], 9, 10]);
+        $new = $arrayObject->collapse();
+
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8], $new->getArrayCopy());
+    }
+
+    public function testReduce()
+    {
+        $arrayObject = new ArrayObject([6, 3, 1]);
+        $total = $arrayObject->reduce(function ($carry, $item) {
+            return $carry + $item;
+        }, 0);
+
+        $this->assertEquals(10, $total);
+    }
+
+    public function testKeys()
+    {
+        $arrayObject = new ArrayObject(['one' => 1, 'two' => 2, 'three' => 3]);
+        $new = $arrayObject->keys();
+
+        $this->assertSame(['one', 'two', 'three'], $new->getArrayCopy());
+    }
+
+    public function testGetReturnsDefaultIfNotSet()
+    {
+        $arrayObject = new ArrayObject(['one' => 1, 'two' => 2, 'three' => 3]);
+        $this->assertEquals(4, $arrayObject->get('four', 4));
+    }
+
+    public function testGet()
+    {
+        $arrayObject = new ArrayObject(['one' => 1, 'two' => 2, 'three' => 3]);
+        $this->assertEquals(3, $arrayObject->get('three'));
+    }
+
+    public function testSet()
+    {
+        $arrayObject = new ArrayObject([1, 2, 3]);
+        $new = $arrayObject->set(3, 4);
+
+        $this->assertNotSame($new, $arrayObject);
+        $this->assertSame([1, 2, 3, 4], $new->getArrayCopy());
+
+        $arrayObject = new ArrayObject(['one' => 1, 'two' => 2, 'three' => 3]);
+        $new = $arrayObject->set('three', 4);
+
+        $this->assertNotSame($new, $arrayObject);
+        $this->assertSame(['one' => 1, 'two' => 2, 'three' => 4], $new->getArrayCopy());
+    }
 }


### PR DESCRIPTION
* Only fetch container entries used for listeners when dispatching the event
* Add some methods + tests to ArrayObject + bring in `Collection` which is basically alias for `ArrayObject` as it looks weird using `ArrayObject` in the code when you want to use collection features.
* Move default event listeners to config and remove from the factory
* Migrate some tests to prophecy - so much nicer ❤️ 
* Change config structure for event listeners to allow grouping together events.

Eg

```php
//before
[
    'some-event' => [
        'CoolFeature1Listener'
        'CoolFeature2Listener'
    ],
    'some-other-event' => [
        'CoolFeature1Listener',
    ]
]
```

```php
//after
[
    'cool-feature1' => [
        'some-event' => [
            'CoolFeature1Listener'
        ],
        'some-other-event' => [
            'CoolFeature1Listener',
        ]
    ]
    'cool-feature2' => [
        'some-event' => [
            'CoolFeature2Listener'
        ],
    ],
]
```
