### PR TITLE
Make sure to pass arguments added by events to the results

### DIFF
--- a/src/ExerciseRunner/CliRunner.php
+++ b/src/ExerciseRunner/CliRunner.php
@@ -194,10 +194,10 @@ class CliRunner implements ExerciseRunnerInterface
             return GenericFailure::fromArgsAndCodeExecutionFailure($args, $e);
         }
         if ($solutionOutput === $userOutput) {
-            return new Success($args);
+            return new Success($event->getArgs());
         }
 
-        return RequestFailure::fromArgsAndOutput($args, $solutionOutput, $userOutput);
+        return RequestFailure::fromArgsAndOutput($event->getArgs(), $solutionOutput, $userOutput);
     }
 
     /**

--- a/test/ExerciseRunner/CliRunnerTest.php
+++ b/test/ExerciseRunner/CliRunnerTest.php
@@ -7,6 +7,7 @@ use PhpSchool\CliMenu\Terminal\TerminalInterface;
 use PhpSchool\PhpWorkshop\Check\CodeParseCheck;
 use PhpSchool\PhpWorkshop\Check\FileExistsCheck;
 use PhpSchool\PhpWorkshop\Check\PhpLintCheck;
+use PhpSchool\PhpWorkshop\Event\CliExecuteEvent;
 use PhpSchool\PhpWorkshop\Event\EventDispatcher;
 use PhpSchool\PhpWorkshop\Exception\SolutionExecutionException;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseType;
@@ -31,14 +32,20 @@ class CliRunnerTest extends PHPUnit_Framework_TestCase
     private $runner;
 
     /**
-     * @var CliExerciseInterface
+     * @var CliExerciseInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $exercise;
+
+    /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
 
     public function setUp()
     {
         $this->exercise = $this->createMock(CliExerciseInterface::class);
-        $this->runner = new CliRunner($this->exercise, new EventDispatcher(new ResultAggregator));
+        $this->eventDispatcher = new EventDispatcher(new ResultAggregator);
+        $this->runner = new CliRunner($this->exercise, $this->eventDispatcher);
 
         $this->exercise
             ->expects($this->any())
@@ -213,5 +220,31 @@ class CliRunnerTest extends PHPUnit_Framework_TestCase
 
         $success = $this->runner->run(new Input('app', ['program' => __DIR__ . '/../res/cli/user-error.php']), $output);
         $this->assertFalse($success);
+    }
+
+    public function testsArgsAppendedByEventsArePassedToResults()
+    {
+        $this->eventDispatcher->listen(['cli.verify.student-execute.pre', 'cli.verify.reference-execute.pre'], function (CliExecuteEvent $e) {
+            $e->appendArg('4');
+        });
+
+        $solution = SingleFileSolution::fromFile(realpath(__DIR__ . '/../res/cli/solution.php'));
+        $this->exercise
+            ->expects($this->once())
+            ->method('getSolution')
+            ->will($this->returnValue($solution));
+
+        $this->exercise
+            ->expects($this->once())
+            ->method('getArgs')
+            ->will($this->returnValue([1, 2, 3]));
+
+        $this->assertInstanceOf(
+            CliResult::class,
+            $res = $this->runner->verify(new Input('app', ['program' => __DIR__ . '/../res/cli/user.php']))
+        );
+
+        $this->assertTrue($res->isSuccessful());
+        $this->assertEquals([1, 2, 3, 4], $res->getResults()[0]->getArgs()->getArrayCopy());
     }
 }

--- a/test/ExerciseRunner/CliRunnerTest.php
+++ b/test/ExerciseRunner/CliRunnerTest.php
@@ -224,9 +224,12 @@ class CliRunnerTest extends PHPUnit_Framework_TestCase
 
     public function testsArgsAppendedByEventsArePassedToResults()
     {
-        $this->eventDispatcher->listen(['cli.verify.student-execute.pre', 'cli.verify.reference-execute.pre'], function (CliExecuteEvent $e) {
-            $e->appendArg('4');
-        });
+        $this->eventDispatcher->listen(
+            ['cli.verify.student-execute.pre', 'cli.verify.reference-execute.pre'],
+            function (CliExecuteEvent $e) {
+                $e->appendArg('4');
+            }
+        );
 
         $solution = SingleFileSolution::fromFile(realpath(__DIR__ . '/../res/cli/solution.php'));
         $this->exercise

--- a/test/res/database/solution.php
+++ b/test/res/database/solution.php
@@ -1,7 +1,7 @@
 <?php
 
 $count = 0;
-for ($i = 1; $i < count($argv); $i++) {
+for ($i = 2; $i < count($argv); $i++) {
     $count += $argv[$i];
 }
 

--- a/test/res/database/user.php
+++ b/test/res/database/user.php
@@ -1,7 +1,7 @@
 <?php
 
 $count = 0;
-for ($i = 1; $i < count($argv); $i++) {
+for ($i = 2; $i < count($argv); $i++) {
     $count += $argv[$i];
 }
 


### PR DESCRIPTION
If we add arguments via events - they previously did not get passed to the results and therefore would not be printed when verify files or when running via `run`. 