### PR TITLE
Run tests on 7.1 & 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,11 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
     - php: 7.0
-      env: SYMFONY_VERSION='2.7.*'
-    - php: 7.0
-      env: SYMFONY_VERSION='2.8.*'
-    - php: 7.0
-      env: SYMFONY_VERSION='3.0.*'
+    - php: 7.1
+    - php: 7.2
 
 before_install:
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
 
 install:
   - composer update $COMPOSER_FLAGS --prefer-dist --optimize-autoloader

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,9 @@
         "php" : ">=5.6",
         "ext-pdo_sqlite": "*",
         "php-di/php-di": "^5.0",
-        "php-di/invoker": "^1.0",
         "container-interop/container-interop": "^1.0",
-        "symfony/process": "^2.3|^3.0",
-        "symfony/filesystem": "^2.3|^3.0",
+        "symfony/process": "^3.0",
+        "symfony/filesystem": "^3.0",
         "fzaninotto/faker": "^1.5",
         "aydin-hassan/cli-md-renderer": "^2.2",
         "php-school/cli-menu": "^2.0",
@@ -50,11 +49,6 @@
     "autoload-dev": {
         "psr-4": { 
             "PhpSchool\\PhpWorkshopTest\\": "test" 
-        }
-    },
-    "extra" : {
-        "branch-alias": {
-            "dev-master": "0.1.x-dev"
         }
     },
     "scripts" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "36e882512617fa9abd64172f698c3d0a",
+    "content-hash": "4c11fd8ea9512bc894e43100a805b60f",
     "packages": [
         {
             "name": "aydin-hassan/cli-md-renderer",


### PR DESCRIPTION
Only runs test on latest version of symfony
Only support symfony 2.x
Test on PHP 7.1 & 7.2

Now that we recommend installing via the `workshop-manager` I don't think we need to support and test symfony 2.x components as our installs are isolated. 