### PR TITLE
Exercise testing utils

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,10 @@ parameters:
         -
             message: '#Call to an undefined method PhpParser\\Node\\Expr\|PhpParser\\Node\\Name\:\:__toString\(\)#'
             path: src/Check/FunctionRequirementsCheck.php
+
+        -
+            message: '#Class PHPUnit\\Framework\\TestCase not found#'
+            path: src/TestUtils/WorkshopExerciseTest.php
+
+    excludes_analyse:
+        - src/TestUtils/WorkshopExerciseTest.php

--- a/src/Application.php
+++ b/src/Application.php
@@ -11,6 +11,7 @@ use PhpSchool\PhpWorkshop\Exception\InvalidArgumentException;
 use PhpSchool\PhpWorkshop\Exception\MissingArgumentException;
 use PhpSchool\PhpWorkshop\Factory\ResultRendererFactory;
 use PhpSchool\PhpWorkshop\Output\OutputInterface;
+use Psr\Container\ContainerInterface;
 use RuntimeException;
 
 use function class_exists;
@@ -160,13 +161,7 @@ final class Application
         $this->bgColour = $colour;
     }
 
-    /**
-     * Executes the framework, invoking the specified command.
-     * The return value is the exit code. 0 for success, anything else is a failure.
-     *
-     * @return int The exit code
-     */
-    public function run(): int
+    public function configure(): ContainerInterface
     {
         $container = $this->getContainer();
 
@@ -196,6 +191,19 @@ final class Application
                 $resultFactory->registerRenderer($result['resultClass'], $result['resultRendererClass']);
             }
         }
+
+        return $container;
+    }
+
+    /**
+     * Executes the framework, invoking the specified command.
+     * The return value is the exit code. 0 for success, anything else is a failure.
+     *
+     * @return int The exit code
+     */
+    public function run(): int
+    {
+        $container = $this->configure();
 
         try {
             $exitCode = $container->get(CommandRouter::class)->route();

--- a/src/ExerciseRepository.php
+++ b/src/ExerciseRepository.php
@@ -81,6 +81,25 @@ class ExerciseRepository implements IteratorAggregate, Countable
     }
 
     /**
+     * Find an exercise by it's class name. If it does not exist
+     * an `InvalidArgumentException` exception is thrown.
+     *
+     * @param class-string $className
+     * @return ExerciseInterface
+     * @throws InvalidArgumentException
+     */
+    public function findByClassName(string $className): ExerciseInterface
+    {
+        foreach ($this->exercises as $exercise) {
+            if ($className === get_class($exercise)) {
+                return $exercise;
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf('Exercise with name: "%s" does not exist', $className));
+    }
+
+    /**
      * Get the names of each exercise as an array.
      *
      * @return array<string>

--- a/src/TestUtils/WorkshopExerciseTest.php
+++ b/src/TestUtils/WorkshopExerciseTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshop\TestUtils;
+
+use PhpSchool\PhpWorkshop\Application;
+use PhpSchool\PhpWorkshop\Exception\InvalidArgumentException;
+use PhpSchool\PhpWorkshop\Exercise\AbstractExercise;
+use PhpSchool\PhpWorkshop\Exercise\ExerciseInterface;
+use PhpSchool\PhpWorkshop\Exercise\ExerciseType;
+use PhpSchool\PhpWorkshop\ExerciseDispatcher;
+use PhpSchool\PhpWorkshop\ExerciseRepository;
+use PhpSchool\PhpWorkshop\Result\Cgi\CgiResult;
+use PhpSchool\PhpWorkshop\Result\Cli\CliResult;
+use PhpSchool\PhpWorkshop\Result\Failure;
+use PhpSchool\PhpWorkshop\Result\FailureInterface;
+use PhpSchool\PhpWorkshop\Result\ResultInterface;
+use PhpSchool\PhpWorkshop\ResultAggregator;
+use PhpSchool\PhpWorkshop\Utils\Collection;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use PhpSchool\PhpWorkshop\Input\Input;
+
+abstract class WorkshopExerciseTest extends TestCase
+{
+    /**
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var ResultAggregator
+     */
+    protected $results;
+
+    public function setUp(): void
+    {
+        $this->app = $this->getApplication();
+        $this->container = $this->app->configure();
+    }
+
+    /**
+     * @return class-string
+     */
+    abstract public function getExerciseClass(): string;
+
+    abstract public function getApplication(): Application;
+
+    private function getExercise(): ExerciseInterface
+    {
+        return $this->container->get(ExerciseRepository::class)
+            ->findByClassName($this->getExerciseClass());
+    }
+
+    public function runExercise(string $submissionFile)
+    {
+        $exercise = $this->getExercise();
+
+        $submissionFileAbsolute = sprintf(
+            '%s/test/solutions/%s/%s',
+            rtrim($this->container->get('basePath'), '/'),
+            AbstractExercise::normaliseName($exercise->getName()),
+            $submissionFile
+        );
+
+        if (!file_exists($submissionFileAbsolute)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Submission file "%s" does not exist in "%s"',
+                    $submissionFile,
+                    dirname($submissionFileAbsolute)
+                )
+            );
+        }
+
+        $input = new Input($this->container->get('appName'), [
+            'program' => $submissionFileAbsolute
+        ]);
+
+        $this->results = $this->container->get(ExerciseDispatcher::class)
+            ->verify($exercise, $input);
+    }
+
+    public function assertVerifyWasSuccessful(): void
+    {
+        $failures = (new Collection($this->results->getIterator()->getArrayCopy()))
+            ->filter(function (ResultInterface $result) {
+                return $result instanceof FailureInterface;
+            })
+            ->map(function (Failure $failure) {
+                return $failure->getReason();
+            })
+            ->implode(', ');
+
+
+        $this->assertTrue($this->results->isSuccessful(), $failures);
+    }
+
+    public function assertVerifyWasNotSuccessful(): void
+    {
+        $failures = (new Collection($this->results->getIterator()->getArrayCopy()))
+            ->filter(function (ResultInterface $result) {
+                return $result instanceof FailureInterface;
+            })
+            ->map(function (FailureInterface $failure) {
+                return get_class($failure);
+            })
+            ->implode(', ');
+
+        $this->assertFalse($this->results->isSuccessful());
+    }
+
+    public function assertResultCount(int $count): void
+    {
+        $this->assertCount($count, $this->results);
+    }
+
+    public function assertResultsHasFailure(string $resultClass, string $reason): void
+    {
+        $failures = (new Collection($this->results->getIterator()->getArrayCopy()))
+            ->filter(function (ResultInterface $result) {
+                return $result instanceof Failure;
+            })
+            ->filter(function (Failure $failure) use ($reason) {
+                return $failure->getReason() === $reason;
+            });
+
+        $this->assertCount(1, $failures, "No failure with reason: '$reason'");
+    }
+
+    public function assertOutputWasIncorrect(): void
+    {
+        $exerciseType = $this->getExercise()->getType();
+
+        if ($exerciseType->equals(ExerciseType::CLI())) {
+            $results = (new Collection($this->results->getIterator()->getArrayCopy()))
+                ->filter(function (ResultInterface $result) {
+                    return $result instanceof CliResult;
+                });
+
+            $this->assertCount(1, $results);
+        }
+
+        if ($exerciseType->equals(ExerciseType::CGI())) {
+            $results = (new Collection($this->results->getIterator()->getArrayCopy()))
+                ->filter(function (ResultInterface $result) {
+                    return $result instanceof CgiResult;
+                });
+
+            $this->assertCount(1, $results);
+        }
+
+        $outputResults = $results->values()->get(0);
+
+        $this->assertFalse($outputResults->isSuccessful());
+    }
+}

--- a/src/TestUtils/WorkshopExerciseTest.php
+++ b/src/TestUtils/WorkshopExerciseTest.php
@@ -104,15 +104,6 @@ abstract class WorkshopExerciseTest extends TestCase
 
     public function assertVerifyWasNotSuccessful(): void
     {
-        $failures = (new Collection($this->results->getIterator()->getArrayCopy()))
-            ->filter(function (ResultInterface $result) {
-                return $result instanceof FailureInterface;
-            })
-            ->map(function (FailureInterface $failure) {
-                return get_class($failure);
-            })
-            ->implode(', ');
-
         $this->assertFalse($this->results->isSuccessful());
     }
 

--- a/src/Utils/ArrayObject.php
+++ b/src/Utils/ArrayObject.php
@@ -108,6 +108,22 @@ class ArrayObject implements IteratorAggregate, Countable
     }
 
     /**
+     * @return static
+     */
+    public function values(): self
+    {
+        return new static(array_values($this->array));
+    }
+
+    /**
+     * @return T|mixed
+     */
+    public function first()
+    {
+        return $this->get(0);
+    }
+
+    /**
      * Implode each item together using the provided glue.
      *
      * @param string $glue
@@ -143,11 +159,11 @@ class ArrayObject implements IteratorAggregate, Countable
     /**
      * Get an item at the given key.
      *
-     * @param string $key
+     * @param string|int $key
      * @param mixed $default
      * @return T|mixed
      */
-    public function get(string $key, $default = null)
+    public function get($key, $default = null)
     {
         return $this->array[$key] ?? $default;
     }

--- a/test/ExerciseRepositoryTest.php
+++ b/test/ExerciseRepositoryTest.php
@@ -45,6 +45,25 @@ class ExerciseRepositoryTest extends TestCase
         $repo->findByName('exercise1');
     }
 
+    public function testFindByClassName(): void
+    {
+        $exercises = [
+            new CliExerciseImpl('Exercise 1'),
+        ];
+
+        $repo = new ExerciseRepository($exercises);
+        $this->assertSame($exercises[0], $repo->findByClassName(CliExerciseImpl::class));
+    }
+
+    public function testFindByClassNameThrowsExceptionIfNotFound(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Exercise with name: "%s" does not exist', CliExerciseImpl::class));
+
+        $repo = new ExerciseRepository([]);
+        $repo->findByClassName(CliExerciseImpl::class);
+    }
+
     public function testGetAllNames(): void
     {
         $exercises = [

--- a/test/Util/ArrayObjectTest.php
+++ b/test/Util/ArrayObjectTest.php
@@ -134,4 +134,33 @@ class ArrayObjectTest extends TestCase
         $arrayObject = new ArrayObject();
         self::assertTrue($arrayObject->isEmpty());
     }
+
+    public function testFilter(): void
+    {
+        $arrayObject = new ArrayObject([1, 2, 3]);
+        $new = $arrayObject->filter(function ($elem) {
+            return $elem > 1;
+        });
+
+        $this->assertNotSame($arrayObject, $new);
+        $this->assertEquals([1 => 2, 2 => 3], $new->getArrayCopy());
+    }
+
+    public function testValues(): void
+    {
+        $arrayObject = new ArrayObject([1, 2, 3]);
+        $new = $arrayObject->filter(function ($elem) {
+            return $elem > 1;
+        });
+
+        $this->assertNotSame($arrayObject, $new);
+        $this->assertEquals([0 => 2, 1 => 3], $new->values()->getArrayCopy());
+    }
+
+    public function testFirst(): void
+    {
+        $arrayObject = new ArrayObject([10, 11, 12]);
+
+        $this->assertEquals(10, $arrayObject->first());
+    }
 }


### PR DESCRIPTION
So I've made this test case so we can test exercises more like integration tests rather than the messy tests we had for learn you php. So now the tests for the Match exercise look like this:

```php
class AMatchMadeInHeavenTest extends WorkshopExerciseTest
{
    public function getApplication(): Application
    {
        return require __DIR__ . '/../../app/bootstrap.php';
    }

    public function getExerciseClass(): string
    {
        return AMatchMadeInHeaven::class;
    }

    public function testWithNoCode(): void
    {
        $this->runExercise('solution-no-code.php');

        $this->assertVerifyWasNotSuccessful();

        $this->assertResultsHasFailure(Failure::class, 'No code was found');
    }

    public function testWithNoMatch(): void
    {
        $this->runExercise('solution-no-match.php');

        $this->assertVerifyWasNotSuccessful();

        $this->assertResultsHasFailure(Failure::class, 'Match not found');
    }

    public function testWithSwitch(): void
    {
        $this->runExercise('solution-switch.php');

        $this->assertVerifyWasNotSuccessful();

        $this->assertResultsHasFailure(Failure::class, 'Switch found');
    }

    public function testWithNoMatchDefault(): void
    {
        $this->runExercise('solution-no-default.php');

        $this->assertVerifyWasNotSuccessful();

        $this->assertResultsHasFailure(Failure::class, 'Match default not found');
    }

    public function testWithIncorrectOutput(): void
    {
        $this->runExercise('solution-wrong-output.php');

        $this->assertVerifyWasNotSuccessful();

        $this->assertOutputWasIncorrect();
    }

    public function testWithCorrectSolution(): void
    {
        $this->runExercise('solution-correct.php');

        $this->assertVerifyWasSuccessful();
    }
}
```