### PR TITLE
Missing problem file

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -219,7 +219,7 @@ final class Application
                     )
                 );
             return 1;
-        } catch (RuntimeException $e) {
+        } catch (\Throwable $e) {
             $container
                 ->get(OutputInterface::class)
                 ->printError(

--- a/src/Application.php
+++ b/src/Application.php
@@ -220,12 +220,19 @@ final class Application
                 );
             return 1;
         } catch (\Throwable $e) {
+            $message = $e->getMessage();
+            $basePath = canonicalise_path($container->get('basePath'));
+
+            if (strpos($message, $basePath) !== null) {
+                $message = str_replace($basePath, '', $message);
+            }
+
             $container
                 ->get(OutputInterface::class)
                 ->printError(
                     sprintf(
                         '%s',
-                        $e->getMessage()
+                        $message
                     )
                 );
             return 1;

--- a/src/Command/PrintCommand.php
+++ b/src/Command/PrintCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpSchool\PhpWorkshop\Command;
 
+use PhpSchool\PhpWorkshop\Exception\InvalidArgumentException;
+use PhpSchool\PhpWorkshop\Exception\ProblemFileDoesNotExistException;
 use PhpSchool\PhpWorkshop\ExerciseRepository;
 use PhpSchool\PhpWorkshop\MarkdownRenderer;
 use PhpSchool\PhpWorkshop\Output\OutputInterface;
@@ -68,7 +70,14 @@ class PrintCommand
         $currentExercise = $this->userState->getCurrentExercise();
         $exercise = $this->exerciseRepository->findByName($currentExercise);
 
-        $markDown = (string) file_get_contents($exercise->getProblem());
+        $problemFile = $exercise->getProblem();
+
+        if (!is_readable($problemFile)) {
+            throw ProblemFileDoesNotExistException::fromFile($problemFile);
+        }
+
+        $markDown = (string) file_get_contents($problemFile);
+
         $doc = $this->markdownRenderer->render($markDown);
         $doc = str_replace('{appname}', $this->appName, $doc);
         $this->output->write($doc);

--- a/src/Exception/ProblemFileDoesNotExistException.php
+++ b/src/Exception/ProblemFileDoesNotExistException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshop\Exception;
+
+class ProblemFileDoesNotExistException extends \RuntimeException
+{
+    public static function fromFile(string $file): self
+    {
+        return new self("Exercise problem file: '$file' does not exist or is not readable");
+    }
+}

--- a/src/Exception/ProblemFileDoesNotExistException.php
+++ b/src/Exception/ProblemFileDoesNotExistException.php
@@ -8,6 +8,9 @@ class ProblemFileDoesNotExistException extends \RuntimeException
 {
     public static function fromFile(string $file): self
     {
-        return new self("Exercise problem file: '$file' does not exist or is not readable");
+        return new self(sprintf(
+            'Exercise problem file: "%s" does not exist or is not readable',
+            canonicalise_path($file)
+        ));
     }
 }

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshop\Exception;
+
+class RuntimeException extends \RuntimeException
+{
+
+}

--- a/src/ExerciseRenderer.php
+++ b/src/ExerciseRenderer.php
@@ -6,6 +6,7 @@ namespace PhpSchool\PhpWorkshop;
 
 use Colors\Color;
 use PhpSchool\CliMenu\CliMenu;
+use PhpSchool\PhpWorkshop\Exception\ProblemFileDoesNotExistException;
 use PhpSchool\PhpWorkshop\Output\OutputInterface;
 
 /**
@@ -100,7 +101,12 @@ class ExerciseRenderer
         $output .= $this->color->__invoke(" " . $exercise->getName())->yellow()->bold() . "\n";
         $output .= $this->color->__invoke(sprintf(" Exercise %d of %d\n\n", $exerciseIndex, $numExercises))->yellow();
 
-        $content = (string) file_get_contents($exercise->getProblem());
+        $problemFile = $exercise->getProblem();
+        if (!is_readable($problemFile)) {
+            throw ProblemFileDoesNotExistException::fromFile($problemFile);
+        }
+
+        $content = (string) file_get_contents($problemFile);
         $doc     = $this->markdownRenderer->render($content);
         $doc     = str_replace('{appname}', $this->appName, $doc);
         $output .= $doc;

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -11,7 +11,7 @@ class StringUtils
     public static function canonicalisePath(string $filename): string
     {
         $path = [];
-        foreach(explode('/', $filename) as $part) {
+        foreach (explode('/', $filename) as $part) {
             // ignore parts that have no value
             if (strlen($part) === 0 || $part === '.') {
                 continue;
@@ -19,7 +19,7 @@ class StringUtils
 
             if ($part !== '..') {
                 $path[] = $part;
-            } else if (count($path) > 0) {
+            } elseif (count($path) > 0) {
                 array_pop($path);
             } else {
                 throw new RuntimeException('Climbing above the root is not permitted.');

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshop\Utils;
+
+use PhpSchool\PhpWorkshop\Exception\RuntimeException;
+
+class StringUtils
+{
+    public static function canonicalisePath(string $filename): string
+    {
+        $path = [];
+        foreach(explode('/', $filename) as $part) {
+            // ignore parts that have no value
+            if (strlen($part) === 0 || $part === '.') {
+                continue;
+            }
+
+            if ($part !== '..') {
+                $path[] = $part;
+            } else if (count($path) > 0) {
+                array_pop($path);
+            } else {
+                throw new RuntimeException('Climbing above the root is not permitted.');
+            }
+        }
+
+        return $filename[0] === '/'
+            ? '/' . implode('/', $path)
+            : implode('/', $path);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpSchool\PhpWorkshop\Utils\StringUtils;
+
 if (!function_exists('mb_str_pad')) {
 
     /**
@@ -29,5 +31,17 @@ if (!function_exists('camel_case_to_kebab_case')) {
         return (string) preg_replace_callback('/[A-Z]/', function ($matches) {
             return '-' . strtolower($matches[0]);
         }, $string);
+    }
+}
+
+if (!function_exists('canonicalise_path')) {
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    function canonicalise_path(string $path): string
+    {
+        return StringUtils::canonicalisePath($path);
     }
 }

--- a/test/Util/StringUtilsTest.php
+++ b/test/Util/StringUtilsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshopTest\Util;
+
+use PhpSchool\PhpWorkshop\Utils\StringUtils;
+use PHPUnit\Framework\TestCase;
+use PhpSchool\PhpWorkshop\Exception\RuntimeException;
+
+class StringUtilsTest extends TestCase
+{
+    public function testCanonicalisePath(): void
+    {
+        $this->assertEquals('/path/to/file', StringUtils::canonicalisePath('/path/to/file'));
+        $this->assertEquals('/path/to/file', StringUtils::canonicalisePath('/path/././to/file'));
+        $this->assertEquals('/path/to/file', StringUtils::canonicalisePath('/path///to/file'));
+        $this->assertEquals('/path/to/file', StringUtils::canonicalisePath('/path/to/file'));
+        $this->assertEquals('/', StringUtils::canonicalisePath('/path/to/../../'));
+        $this->assertEquals('/path', StringUtils::canonicalisePath('/path/to/some/../../'));
+        $this->assertEquals('/some', StringUtils::canonicalisePath('/path/../some/'));
+        $this->assertEquals('some', StringUtils::canonicalisePath('path/../some/'));
+    }
+
+    public function testExceptionIsThrownIfTryingToTraverseUpPastRoom(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Climbing above the root is not permitted.');
+
+        StringUtils::canonicalisePath('/path/to/../../../');
+    }
+}


### PR DESCRIPTION
Throw an exception when a problem file doesn't exist for better DX

* Also add better error reporting, we were not catching many exceptions in the Application class before. Now we catch all of them.
* Also add a `canonicalise_path` function to resolve `../../` in paths
* Strip workshop `base_path` off file path in exception to make exception printing prettier.