### PR TITLE
Use array_values to fix indexes

### DIFF
--- a/src/NodeVisitor/FunctionVisitor.php
+++ b/src/NodeVisitor/FunctionVisitor.php
@@ -112,7 +112,7 @@ class FunctionVisitor extends NodeVisitorAbstract
      */
     public function getMissingRequirements(): array
     {
-        return array_filter($this->requiredFunctions, function ($function) {
+        return array_values(array_filter($this->requiredFunctions, function ($function) {
             foreach ($this->getRequiredUsages() as $usage) {
                 if (!$usage->name instanceof Node\Name) {
                     continue;
@@ -123,6 +123,6 @@ class FunctionVisitor extends NodeVisitorAbstract
                 }
             }
             return true;
-        });
+        }));
     }
 }

--- a/test/NodeVisitor/FunctionVisitorTest.php
+++ b/test/NodeVisitor/FunctionVisitorTest.php
@@ -50,4 +50,15 @@ class FunctionVisitorTest extends TestCase
         $this->assertFalse($visitor->hasUsedBannedFunctions());
         $this->assertSame([], $visitor->getBannedUsages());
     }
+
+    public function testLeaveNodeWithMultipleRequirements(): void
+    {
+        $node = new FuncCall(new Name('file'));
+        $visitor = new FunctionVisitor(['file', 'file_get_contents'], []);
+        $visitor->leaveNode($node);
+
+        $this->assertSame([$node], $visitor->getRequiredUsages());
+        $this->assertFalse($visitor->hasMetFunctionRequirements());
+        $this->assertSame(['file_get_contents'], $visitor->getMissingRequirements());
+    }
 }


### PR DESCRIPTION
Found this when writing a test for an exercise which required multiple function usages but only one was used.