### PR TITLE
Allow function requirements check to run before selfcheck (and other …

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Colors\Color;
+use PhpSchool\PhpWorkshop\Check\FunctionRequirementsBeforeCheck;
 use PhpSchool\PhpWorkshop\Listener\InitialCodeListener;
 use PhpSchool\PhpWorkshop\Logger\Logger;
 use Psr\Log\LoggerInterface;
@@ -113,6 +114,7 @@ return [
             $c->get(CodeParseCheck::class),
             $c->get(ComposerCheck::class),
             $c->get(FunctionRequirementsCheck::class),
+            $c->get(FunctionRequirementsBeforeCheck::class),
             $c->get(DatabaseCheck::class),
         ]);
     },

--- a/app/config.php
+++ b/app/config.php
@@ -239,16 +239,19 @@ return [
     RealPathListener::class => create(),
 
     //checks
-    FileExistsCheck::class              => create(),
-    PhpLintCheck::class                 => create(),
-    CodeParseCheck::class               => function (ContainerInterface $c) {
+    FileExistsCheck::class => create(),
+    PhpLintCheck::class => create(),
+    CodeParseCheck::class => function (ContainerInterface $c) {
         return new CodeParseCheck($c->get(Parser::class));
     },
-    FunctionRequirementsCheck::class    => function (ContainerInterface $c) {
+    FunctionRequirementsCheck::class => function (ContainerInterface $c) {
         return new FunctionRequirementsCheck($c->get(Parser::class));
     },
-    DatabaseCheck::class                => create(),
-    ComposerCheck::class                => create(),
+    FunctionRequirementsBeforeCheck::class => function (ContainerInterface $c) {
+        return new FunctionRequirementsBeforeCheck($c->get(Parser::class));
+    },
+    DatabaseCheck::class => create(),
+    ComposerCheck::class => create(),
 
     //Utils
     Filesystem::class   => create(),

--- a/src/Check/FunctionRequirementsBeforeCheck.php
+++ b/src/Check/FunctionRequirementsBeforeCheck.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshop\Check;
+
+/**
+ * This check verifies that the student's solution contains usages of some required functions
+ * and also does not use certain functions (specified by the exercise).
+ */
+class FunctionRequirementsBeforeCheck extends FunctionRequirementsCheck
+{
+    /**
+     * This is performed BEFORE executing the student's solution to short circuit further
+     * checks from running.
+     */
+    public function getPosition(): string
+    {
+        return SimpleCheckInterface::CHECK_BEFORE;
+    }
+}


### PR DESCRIPTION
…checks)

This is not really a great solution and maybe it should be up to exercises where to insert checks (before or after cli/cgi verifying) but I don't want to get stuck in that code atm. For an exercise I'm writing now I don't want to write code which returns failures when it can't find a function call in the AST, so I duplicated this check which will short circuit the self checking if the function call doesn't exist.