### PR TITLE
Pushes all solution files into temp when created

### DIFF
--- a/src/Solution/DirectorySolution.php
+++ b/src/Solution/DirectorySolution.php
@@ -85,6 +85,7 @@ class DirectorySolution implements SolutionInterface
      */
     public static function fromDirectory(string $directory, array $exclusions = [], $entryPoint = 'solution.php'): self
     {
+        $directory = InTempSolutionMapper::mapDirectory($directory);
         return new self($directory, $entryPoint, array_merge($exclusions, ['composer.lock', 'vendor']));
     }
 

--- a/src/Solution/InTempSolutionMapper.php
+++ b/src/Solution/InTempSolutionMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshop\Solution;
+
+use PhpSchool\PhpWorkshop\Utils\Path;
+use PhpSchool\PhpWorkshop\Utils\System;
+use Symfony\Component\Filesystem\Filesystem;
+
+class InTempSolutionMapper
+{
+    public static function mapDirectory(string $directory): string
+    {
+        $fileSystem = new Filesystem();
+        $tempDir = self::getRandomTempDir();
+
+        $fileSystem->mkdir($tempDir);
+
+        $dirIterator = new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS);
+        $iterator = new \RecursiveIteratorIterator($dirIterator, \RecursiveIteratorIterator::SELF_FIRST);
+
+        foreach ($iterator as $file) {
+            $target = Path::join($tempDir, $iterator->getSubPathName());
+            $file->isDir()
+                ? $fileSystem->mkdir($target)
+                : $fileSystem->copy($file->getPathname(), $target);
+        }
+
+        return $tempDir;
+    }
+
+    public static function mapFile(string $file): string
+    {
+        $fileSystem = new Filesystem();
+        $tempFile = Path::join(self::getRandomTempDir(), basename($file));
+
+        $fileSystem->mkdir(System::tempDir());
+        $fileSystem->copy($file, $tempFile);
+
+        return $tempFile;
+    }
+
+    private static function getRandomTempDir(): string
+    {
+        return Path::join(System::tempDir(), 'php-school', bin2hex(random_bytes(10)));
+    }
+}

--- a/src/Solution/InTempSolutionMapper.php
+++ b/src/Solution/InTempSolutionMapper.php
@@ -13,7 +13,7 @@ class InTempSolutionMapper
     public static function mapDirectory(string $directory): string
     {
         $fileSystem = new Filesystem();
-        $tempDir = self::getRandomTempDir();
+        $tempDir = self::getDeterministicTempDir($directory);
 
         $fileSystem->mkdir($tempDir);
 
@@ -22,6 +22,11 @@ class InTempSolutionMapper
 
         foreach ($iterator as $file) {
             $target = Path::join($tempDir, $iterator->getSubPathName());
+
+            if ($fileSystem->exists($target)) {
+                continue;
+            }
+
             $file->isDir()
                 ? $fileSystem->mkdir($target)
                 : $fileSystem->copy($file->getPathname(), $target);
@@ -33,7 +38,11 @@ class InTempSolutionMapper
     public static function mapFile(string $file): string
     {
         $fileSystem = new Filesystem();
-        $tempFile = Path::join(self::getRandomTempDir(), basename($file));
+        $tempFile = Path::join(self::getDeterministicTempDir($file), basename($file));
+
+        if ($fileSystem->exists($tempFile)) {
+            return $tempFile;
+        }
 
         $fileSystem->mkdir(System::tempDir());
         $fileSystem->copy($file, $tempFile);
@@ -41,8 +50,8 @@ class InTempSolutionMapper
         return $tempFile;
     }
 
-    private static function getRandomTempDir(): string
+    private static function getDeterministicTempDir(string $path): string
     {
-        return Path::join(System::tempDir(), 'php-school', bin2hex(random_bytes(10)));
+        return Path::join(System::tempDir(), 'php-school', md5($path));
     }
 }

--- a/src/Solution/SingleFileSolution.php
+++ b/src/Solution/SingleFileSolution.php
@@ -38,7 +38,7 @@ class SingleFileSolution implements SolutionInterface
      */
     public static function fromFile(string $file): self
     {
-        return new self($file);
+        return new self(InTempSolutionMapper::mapFile($file));
     }
 
     /**

--- a/test/Exercise/AbstractExerciseTest.php
+++ b/test/Exercise/AbstractExerciseTest.php
@@ -26,12 +26,10 @@ class AbstractExerciseTest extends TestCase
         $path       = __DIR__ . '/../../exercises/array-we-go/solution/solution.php';
         mkdir(dirname($path), 0777, true);
         touch($path);
-        $solution = $exercise->getSolution();
-        $this->assertInstanceOf(SolutionInterface::class, $solution);
-        $files = $solution->getFiles();
-        $this->assertCount(1, $files);
-        $this->assertInstanceOf(SolutionFile::class, $files[0]);
-        $this->assertSame(realpath($path), $files[0]->__toString());
+        $files = $exercise->getSolution()->getFiles();
+        self::assertCount(1, $files);
+        self::assertInstanceOf(SolutionFile::class, $files[0]);
+        self::assertFileEquals(realpath($path), $files[0]->__toString());
         unlink($path);
         rmdir(__DIR__ . '/../../exercises/array-we-go/solution');
         rmdir(__DIR__ . '/../../exercises/array-we-go');

--- a/test/Solution/InTempSolutionMapperTest.php
+++ b/test/Solution/InTempSolutionMapperTest.php
@@ -43,15 +43,53 @@ class InTempSolutionMapperTest extends TestCase
         self::assertStringContainsString(realpath(sys_get_temp_dir()), $mappedDir);
     }
 
-    public function testMappingIsInFreshTempDir(): void
+    public function testMappingIsDeterministicTempDir(): void
     {
         $filePath  = Path::join(realpath(sys_get_temp_dir()), 'test.file');
         touch($filePath);
 
-        $tempDir = Path::join(realpath(sys_get_temp_dir()), bin2hex(random_bytes(10)));
+        $dirName = bin2hex(random_bytes(10));
+        $tempDir = Path::join(realpath(sys_get_temp_dir()), $dirName);
         @mkdir($tempDir);
 
-        self::assertNotSame(InTempSolutionMapper::mapFile($filePath), InTempSolutionMapper::mapFile($filePath));
-        self::assertNotSame(InTempSolutionMapper::mapDirectory($tempDir), InTempSolutionMapper::mapDirectory($tempDir));
+        $fileHash = md5($filePath);
+        $dirHash = md5($tempDir);
+
+        self::assertSame(
+            InTempSolutionMapper::mapFile($filePath),
+            Path::join(realpath(sys_get_temp_dir()), 'php-school', $fileHash, 'test.file')
+        );
+
+        self::assertNotSame(
+            InTempSolutionMapper::mapDirectory($tempDir),
+            Path::join(realpath(sys_get_temp_dir()), 'php-school', $dirHash, $dirName)
+        );
+    }
+
+    public function testContentsAreNotOverwroteIfExists(): void
+    {
+        $filePath = Path::join(realpath(sys_get_temp_dir()), 'test.file');
+        file_put_contents($filePath, 'Old contents');
+
+        $dirName = bin2hex(random_bytes(10));
+        $tempDir = Path::join(realpath(sys_get_temp_dir()), $dirName);
+        mkdir($tempDir);
+        file_put_contents(Path::join($tempDir, 'test.file'), 'Old contents');
+
+        $tempFilePath = Path::join(realpath(sys_get_temp_dir()), 'php-school', md5($filePath), 'test.file');
+        $tempDirPath = Path::join(realpath(sys_get_temp_dir()), 'php-school', md5($tempDir), $dirName);
+
+        file_put_contents($tempFilePath, 'Fresh contents');
+        mkdir($tempDirPath, 0777, true);
+        file_put_contents(Path::join($tempDirPath, 'test.file'), 'Fresh contents');
+
+        // These calls will invoke the copying of of dir/files to temp
+        InTempSolutionMapper::mapFile($filePath);
+        InTempSolutionMapper::mapDirectory($tempDir);
+
+        self::assertSame('Old contents', file_get_contents($filePath));
+        self::assertSame('Fresh contents', file_get_contents($tempFilePath));
+        self::assertSame('Old contents', file_get_contents(Path::join($tempDir, 'test.file')));
+        self::assertSame('Fresh contents', file_get_contents(Path::join($tempDirPath, 'test.file')));
     }
 }

--- a/test/Solution/InTempSolutionMapperTest.php
+++ b/test/Solution/InTempSolutionMapperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solution;
+
+use PhpSchool\PhpWorkshop\Solution\InTempSolutionMapper;
+use PhpSchool\PhpWorkshop\Utils\Path;
+use PHPUnit\Framework\TestCase;
+
+class InTempSolutionMapperTest extends TestCase
+{
+    public function testFileMapping(): void
+    {
+        $filePath  = Path::join(realpath(sys_get_temp_dir()), 'test.file');
+        touch($filePath);
+
+        $mappedFile = InTempSolutionMapper::mapFile($filePath);
+
+        self::assertFileExists($mappedFile);
+        self::assertNotSame($filePath, $mappedFile);
+        self::assertStringContainsString(realpath(sys_get_temp_dir()), $mappedFile);
+    }
+
+    public function testDirectoryMapping(): void
+    {
+        $tempDir = Path::join(realpath(sys_get_temp_dir()), bin2hex(random_bytes(10)));
+        $file  = Path::join($tempDir, 'test.file');
+        $inner = Path::join($tempDir, 'innerDir');
+        $innerFile  = Path::join($inner, 'test.file');
+        @mkdir($tempDir);
+        touch($file);
+        @mkdir($inner);
+        touch($innerFile);
+
+        $mappedDir = InTempSolutionMapper::mapDirectory($tempDir);
+
+        self::assertDirectoryExists($mappedDir);
+        self::assertDirectoryExists(Path::join($mappedDir, 'innerDir'));
+        self::assertFileExists(Path::join($mappedDir, 'test.file'));
+        self::assertFileExists(Path::join($mappedDir, 'innerDir', 'test.file'));
+        self::assertNotSame($tempDir, $mappedDir);
+        self::assertStringContainsString(realpath(sys_get_temp_dir()), $mappedDir);
+    }
+
+    public function testMappingIsInFreshTempDir(): void
+    {
+        $filePath  = Path::join(realpath(sys_get_temp_dir()), 'test.file');
+        touch($filePath);
+
+        $tempDir = Path::join(realpath(sys_get_temp_dir()), bin2hex(random_bytes(10)));
+        @mkdir($tempDir);
+
+        self::assertNotSame(InTempSolutionMapper::mapFile($filePath), InTempSolutionMapper::mapFile($filePath));
+        self::assertNotSame(InTempSolutionMapper::mapDirectory($tempDir), InTempSolutionMapper::mapDirectory($tempDir));
+    }
+}

--- a/test/Solution/SingleFileSolutionTest.php
+++ b/test/Solution/SingleFileSolutionTest.php
@@ -13,15 +13,14 @@ class SingleFileSolutionTest extends TestCase
         $filePath   = sprintf('%s/test.file', $tempPath);
 
         @mkdir($tempPath, 0775, true);
-        touch($filePath);
+        file_put_contents($filePath, 'FILE CONTENTS');
 
         $solution = SingleFileSolution::fromFile($filePath);
 
-        $this->assertSame($filePath, $solution->getEntryPoint());
-        $this->assertSame($tempPath, $solution->getBaseDirectory());
-        $this->assertFalse($solution->hasComposerFile());
-        $this->assertCount(1, $solution->getFiles());
-        $this->assertSame($filePath, $solution->getFiles()[0]->__toString());
+        self::assertSame('FILE CONTENTS', file_get_contents($solution->getEntryPoint()));
+        self::assertFalse($solution->hasComposerFile());
+        self::assertCount(1, $solution->getFiles());
+        self::assertSame('FILE CONTENTS', file_get_contents($solution->getFiles()[0]->__toString()));
         unlink($filePath);
         rmdir($tempPath);
     }


### PR DESCRIPTION
Part 1 of ? that replaces #201 with a more sane implementation in smaller more digestible chunks 😄 

This will ensure that our internal solutions are moved into temp before running which in turn allows us to patch the files without any impact to our actual solutions. The risk of breaking these solutions from a users code is high as it essentially breaks the whole workshop 