### PR TITLE
Debug logger

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Colors\Color;
 use PhpSchool\PhpWorkshop\Listener\InitialCodeListener;
+use PhpSchool\PhpWorkshop\Logger\ConsoleLogger;
 use PhpSchool\PhpWorkshop\Logger\Logger;
 use Psr\Log\LoggerInterface;
 use function DI\create;
@@ -95,6 +96,10 @@ return [
     Psr\Log\LoggerInterface::class => function (ContainerInterface $c) {
         $appName = $c->get('appName');
         $globalDir = $c->get('phpschoolGlobalDir');
+
+        if ($c->get('debugMode')) {
+            return new ConsoleLogger($c->get(OutputInterface::class));
+        }
 
         return new Logger("$globalDir/logs/$appName.log");
     },

--- a/app/config.php
+++ b/app/config.php
@@ -98,7 +98,7 @@ return [
         $globalDir = $c->get('phpschoolGlobalDir');
 
         if ($c->get('debugMode')) {
-            return new ConsoleLogger($c->get(OutputInterface::class));
+            return new ConsoleLogger($c->get(OutputInterface::class), $c->get(Color::class));
         }
 
         return new Logger("$globalDir/logs/$appName.log");

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "php-school/keylighter": "^0.8.4",
         "nikic/php-parser": "^4.0",
         "guzzlehttp/guzzle": "^7.2",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "ext-json": "*"
     },
     "require-dev": {
         "composer/composer": "^2.0",

--- a/src/Application.php
+++ b/src/Application.php
@@ -169,13 +169,13 @@ final class Application
         $this->bgColour = $colour;
     }
 
-    public function configure(): ContainerInterface
+    public function configure(bool $debugMode = false): ContainerInterface
     {
         if ($this->container instanceof ContainerInterface) {
             return $this->container;
         }
 
-        $container = $this->getContainer();
+        $container = $this->getContainer($debugMode);
 
         foreach ($this->exercises as $exercise) {
             if (false === $container->has($exercise)) {
@@ -221,10 +221,20 @@ final class Application
      */
     public function run(): int
     {
-        $container = $this->configure();
+        $args = $_SERVER['argv'] ?? [];
+
+        $debug = array_reduce($args, function (bool $debugEnabled, string $arg) {
+            return $debugEnabled || $arg === '--debug';
+        }, false);
+
+        $args = array_values(array_filter($args, function (string $arg) {
+            return $arg !== '--debug';
+        }));
+
+        $container = $this->configure($debug);
 
         try {
-            $exitCode = $container->get(CommandRouter::class)->route();
+            $exitCode = $container->get(CommandRouter::class)->route($args);
         } catch (MissingArgumentException $e) {
             $container
                 ->get(OutputInterface::class)
@@ -261,9 +271,10 @@ final class Application
     }
 
     /**
+     * @param bool $debugMode
      * @return Container
      */
-    private function getContainer(): Container
+    private function getContainer(bool $debugMode): Container
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addDefinitions(
@@ -276,6 +287,7 @@ final class Application
         $containerBuilder->addDefinitions(
             [
                 'workshopTitle' => $this->workshopTitle,
+                'debugMode'     => $debugMode,
                 'exercises'     => $this->exercises,
                 'workshopLogo'  => $this->logo,
                 'bgColour'      => $this->bgColour,

--- a/src/Application.php
+++ b/src/Application.php
@@ -223,9 +223,9 @@ final class Application
     {
         $args = $_SERVER['argv'] ?? [];
 
-        $debug = array_reduce($args, function (bool $debugEnabled, string $arg) {
-            return $debugEnabled || $arg === '--debug';
-        }, false);
+        $debug = any($args, function (string $arg) {
+            return $arg === '--debug';
+        });
 
         $args = array_values(array_filter($args, function (string $arg) {
             return $arg !== '--debug';

--- a/src/CommandRouter.php
+++ b/src/CommandRouter.php
@@ -100,7 +100,6 @@ class CommandRouter
      */
     public function route(array $args = null): int
     {
-
         if (null === $args) {
             $args = $_SERVER['argv'] ?? [];
         }

--- a/src/ExerciseRenderer.php
+++ b/src/ExerciseRenderer.php
@@ -82,8 +82,6 @@ class ExerciseRenderer
      */
     public function __invoke(CliMenu $menu): void
     {
-        $menu->close();
-
         $item = $menu->getSelectedItem();
         $exercise = $this->exerciseRepository->findByName($item->getText());
         $exercises = $this->exerciseRepository->findAll();

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -59,6 +59,7 @@ class MenuFactory
             $builder->addItem(
                 $exercise->getName(),
                 function (CliMenu $menu) use ($exerciseRenderer, $eventDispatcher, $exercise) {
+                    $menu->close();
                     $this->dispatchExerciseSelectedEvent($eventDispatcher, $exercise);
                     $exerciseRenderer->__invoke($menu);
                 },

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSchool\PhpWorkshop\Logger;
+
+use PhpSchool\PhpWorkshop\Output\OutputInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+class ConsoleLogger extends AbstractLogger implements LoggerInterface
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->output->writeLine(sprintf(
+            "Time: %s, Level: %s, Message: %s, Context: %s",
+            (new \DateTime())->format('d-m-y H:i:s'),
+            $level,
+            $message,
+            json_encode($context)
+        ));
+    }
+}

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpSchool\PhpWorkshop\Logger;
 
+use Colors\Color;
 use PhpSchool\PhpWorkshop\Output\OutputInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
@@ -15,19 +16,29 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
      */
     private $output;
 
-    public function __construct(OutputInterface $output)
+    /**
+     * @var Color
+     */
+    private $color;
+
+    public function __construct(OutputInterface $output, Color $color)
     {
         $this->output = $output;
+        $this->color = $color;
     }
 
     public function log($level, $message, array $context = []): void
     {
-        $this->output->writeLine(sprintf(
-            "Time: %s, Level: %s, Message: %s, Context: %s",
-            (new \DateTime())->format('d-m-y H:i:s'),
-            $level,
-            $message,
-            json_encode($context)
-        ));
+        $parts = [
+            sprintf(
+                '%s - %s - %s',
+                $this->color->fg('yellow', (new \DateTime())->format('H:i:s')),
+                $this->color->bg('red', strtoupper($level)),
+                $this->color->fg('red', $message)
+            ),
+            json_encode($context, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        ];
+
+        $this->output->writeLine(implode("\n", $parts));
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -73,3 +73,14 @@ if (!function_exists('collect')) {
         return new Collection($array);
     }
 }
+
+
+if (!function_exists('any')) {
+
+    function any(array $values, callable $cb): bool
+    {
+        return array_reduce($values, function (bool $carry, $value) use ($cb) {
+            return $carry || $cb($value);
+        }, false);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -77,6 +77,11 @@ if (!function_exists('collect')) {
 
 if (!function_exists('any')) {
 
+    /**
+     * @param array<mixed> $values
+     * @param callable $cb
+     * @return bool
+     */
     function any(array $values, callable $cb): bool
     {
         return array_reduce($values, function (bool $carry, $value) use ($cb) {

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -167,19 +167,9 @@ LOCAL;
 
     public function testDebugFlagSwitchesLoggerToConsoleLogger(): void
     {
-        $app = new Application('My workshop', __DIR__ . '/../app/config.php');
-
-        $frameworkFile = sprintf('%s/%s', sys_get_temp_dir(), uniqid($this->getName(), true));
-        file_put_contents($frameworkFile, '<?php return []; ');
-
-        $rp = new \ReflectionProperty(Application::class, 'frameworkConfigLocation');
-        $rp->setAccessible(true);
-        $rp->setValue($app, $frameworkFile);
-
-        $rm = new \ReflectionMethod($app, 'getContainer');
-        $rm->setAccessible(true);
-
-        $container = $rm->invoke($app, true);
+        $configFile = $this->getTemporaryFile('config.php', '<?php return [];');
+        $application = new Application('My workshop', $configFile);
+        $container = $application->configure(true);
 
         $container->set('phpschoolGlobalDir', $this->getTemporaryDirectory());
         $container->set('appName', 'my-workshop');

--- a/test/BaseTest.php
+++ b/test/BaseTest.php
@@ -16,10 +16,8 @@ abstract class BaseTest extends TestCase
     public function getTemporaryDirectory(): string
     {
         if (!$this->tempDirectory) {
-            $tempDirectory = System::tempDir($this->getName());
-            mkdir($tempDirectory, 0777, true);
-
-            $this->tempDirectory = realpath($tempDirectory);
+            $this->tempDirectory = System::tempDir($this->getName());
+            mkdir($this->tempDirectory, 0777, true);
         }
 
         return $this->tempDirectory;

--- a/test/ExerciseRendererTest.php
+++ b/test/ExerciseRendererTest.php
@@ -33,10 +33,6 @@ class ExerciseRendererTest extends TestCase
             ->method('getSelectedItem')
             ->willReturn($item);
 
-        $menu
-            ->expects($this->once())
-            ->method('close');
-
         $exercise1 = $this->createMock(ExerciseInterface::class);
         $exercise2 = $this->createMock(ExerciseInterface::class);
         $exercises = [$exercise1, $exercise2];

--- a/test/FunctionsTest.php
+++ b/test/FunctionsTest.php
@@ -40,4 +40,15 @@ class FunctionsTest extends TestCase
             ]
         ];
     }
+
+    public function testAny(): void
+    {
+        self::assertEquals(true, any([1, 2, 3, 10, 11], function (int $num) {
+            return $num > 10;
+        }));
+
+        self::assertEquals(false, any([1, 2, 3, 10, 11], function (int $num) {
+            return $num > 11;
+        }));
+    }
 }

--- a/test/Logger/ConsoleLoggerTest.php
+++ b/test/Logger/ConsoleLoggerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PhpSchool\PhpWorkshopTest\Logger;
+
+use PhpSchool\CliMenu\Util\StringUtil;
+use PhpSchool\PhpWorkshop\Logger\ConsoleLogger;
+use PhpSchool\PhpWorkshop\Utils\StringUtils;
+use PhpSchool\PhpWorkshopTest\ContainerAwareTest;
+use Psr\Log\LoggerInterface;
+
+class ConsoleLoggerTest extends ContainerAwareTest
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container->set('phpschoolGlobalDir', $this->getTemporaryDirectory());
+        $this->container->set('appName', 'my-workshop');
+        $this->container->set('debugMode', true);
+    }
+
+    public function testConsoleLoggerIsCreatedIfDebugModeEnable(): void
+    {
+        $this->assertInstanceOf(ConsoleLogger::class, $this->container->get(LoggerInterface::class));
+    }
+
+    public function testLoggerWithContext(): void
+    {
+        $logger = $this->container->get(LoggerInterface::class);
+        $logger->critical('Failed to copy file', ['exercise' => 'my-exercise']);
+
+        $out = StringUtil::stripAnsiEscapeSequence($this->getActualOutputForAssertion());
+
+        $match  = '/\d{2}\:\d{2}\:\d{2} - CRITICAL - Failed to copy file\n{\n    "exercise": "my-exercise"\n}/';
+        $this->assertMatchesRegularExpression($match, $out);
+    }
+}

--- a/test/Logger/LoggerTest.php
+++ b/test/Logger/LoggerTest.php
@@ -15,6 +15,7 @@ class LoggerTest extends ContainerAwareTest
 
         $this->container->set('phpschoolGlobalDir', $this->getTemporaryDirectory());
         $this->container->set('appName', 'my-workshop');
+        $this->container->set('debugMode', false);
     }
 
     public function testLoggerDoesNotCreateFileIfNoMessageIsLogged(): void


### PR DESCRIPTION
Adds a new `--debug` flag which will print all logging to the console if present.

I had to refactor the menu closing, because that was currently done in the `ExerciseRenderer` which seems odd anyway, but that was causing the screen to be cleared _after_ the exercise selected event was triggered, so anything logged then would be overwritten. I've changed it to close the menu as soon as we are in the callback for selecting an exercise.