### PR TITLE
Fix type check + mkdir

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -270,7 +270,7 @@ return [
     },
     CodePatcher::class  => function (ContainerInterface $c) {
         $patch = (new Patch)
-            ->withInsertion(new Insertion(Insertion::TYPE_BEFORE, 'ini_set("display_errors", 1);'))
+            ->withInsertion(new Insertion(Insertion::TYPE_BEFORE, 'ini_set("display_errors", "1");'))
             ->withInsertion(new Insertion(Insertion::TYPE_BEFORE, 'error_reporting(E_ALL);'))
             ->withInsertion(new Insertion(Insertion ::TYPE_BEFORE, 'date_default_timezone_set("Europe/London");'));
 

--- a/src/Solution/InTempSolutionMapper.php
+++ b/src/Solution/InTempSolutionMapper.php
@@ -44,7 +44,7 @@ class InTempSolutionMapper
             return $tempFile;
         }
 
-        $fileSystem->mkdir(System::tempDir());
+        $fileSystem->mkdir(dirname($tempFile));
         $fileSystem->copy($file, $tempFile);
 
         return $tempFile;


### PR DESCRIPTION
`ini_set` only accepts strings 😱 - found only with a `strict_types` patch.

The other, the `mkdir` I think was wrong, but can you double check @mikeymike 