### PR TITLE
Force strict types patch

### DIFF
--- a/src/CodePatcher.php
+++ b/src/CodePatcher.php
@@ -123,7 +123,10 @@ class CodePatcher
 
     public function isFirstStatementStrictTypesDeclare(array $statements): bool
     {
-        return isset($statements[0]) && $statements[0] instanceof Declare_;
+        return isset($statements[0])
+            && $statements[0] instanceof Declare_
+            && isset($statements[0]->declares[0])
+            && $statements[0]->declares[0]->key->name === 'strict_types';
     }
 
     /**

--- a/src/CodePatcher.php
+++ b/src/CodePatcher.php
@@ -121,6 +121,9 @@ class CodePatcher
         return $this->printer->prettyPrintFile($statements);
     }
 
+    /**
+     * @param array<Stmt> $statements
+     */
     public function isFirstStatementStrictTypesDeclare(array $statements): bool
     {
         return isset($statements[0])

--- a/src/CodePatcher.php
+++ b/src/CodePatcher.php
@@ -92,12 +92,12 @@ class CodePatcher
             $statements = [];
         }
 
-        $declare = null;
-        if ($this->isFirstStatementStrictTypesDeclare($statements)) {
-            $declare = array_shift($statements);
-        }
-
         foreach ($patch->getModifiers() as $modifier) {
+            $declare = null;
+            if ($this->isFirstStatementStrictTypesDeclare($statements)) {
+                $declare = array_shift($statements);
+            }
+
             if ($modifier instanceof CodeInsertion) {
                 $statements = $this->applyCodeInsertion($modifier, $statements);
             }
@@ -109,10 +109,10 @@ class CodePatcher
             if ($modifier instanceof Transformer) {
                 $statements = $modifier->transform($statements);
             }
-        }
 
-        if ($declare !== null && !$this->isFirstStatementStrictTypesDeclare($statements)) {
-            array_unshift($statements, $declare);
+            if ($declare !== null && !$this->isFirstStatementStrictTypesDeclare($statements)) {
+                array_unshift($statements, $declare);
+            }
         }
 
         return $this->printer->prettyPrintFile($statements);

--- a/src/CodePatcher.php
+++ b/src/CodePatcher.php
@@ -11,6 +11,7 @@ use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseInterface;
 use PhpSchool\PhpWorkshop\Exercise\SubmissionPatchable;
+use PhpSchool\PhpWorkshop\Patch\Transformer;
 
 /**
  * Service to apply patches to a student's solution. Accepts a default patch via the constructor.
@@ -102,8 +103,13 @@ class CodePatcher
                 continue;
             }
 
-            if (is_callable($modifier)) {
+            if ($modifier instanceof \Closure) {
                 $statements = $modifier($statements);
+                continue;
+            }
+
+            if ($modifier instanceof Transformer) {
+                $statements = $modifier->transform($statements);
                 continue;
             }
         }

--- a/src/CodePatcher.php
+++ b/src/CodePatcher.php
@@ -100,17 +100,14 @@ class CodePatcher
         foreach ($patch->getModifiers() as $modifier) {
             if ($modifier instanceof CodeInsertion) {
                 $statements = $this->applyCodeInsertion($modifier, $statements);
-                continue;
             }
 
             if ($modifier instanceof \Closure) {
                 $statements = $modifier($statements);
-                continue;
             }
 
             if ($modifier instanceof Transformer) {
                 $statements = $modifier->transform($statements);
-                continue;
             }
         }
 

--- a/src/CodePatcher.php
+++ b/src/CodePatcher.php
@@ -6,6 +6,7 @@ namespace PhpSchool\PhpWorkshop;
 
 use PhpParser\Error;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
 use PhpSchool\PhpWorkshop\Exercise\ExerciseInterface;
@@ -91,7 +92,7 @@ class CodePatcher
         }
 
         $declare = null;
-        if (isset($statements[0]) && $statements[0] instanceof \PhpParser\Node\Stmt\Declare_) {
+        if ($this->isFirstStatementStrictTypesDeclare($statements)) {
             $declare = array_shift($statements);
         }
 
@@ -107,11 +108,16 @@ class CodePatcher
             }
         }
 
-        if ($declare !== null) {
+        if ($declare !== null && !$this->isFirstStatementStrictTypesDeclare($statements)) {
             array_unshift($statements, $declare);
         }
 
         return $this->printer->prettyPrintFile($statements);
+    }
+
+    public function isFirstStatementStrictTypesDeclare(array $statements): bool
+    {
+        return isset($statements[0]) && $statements[0] instanceof Declare_;
     }
 
     /**

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -5,19 +5,23 @@ declare(strict_types=1);
 namespace PhpSchool\PhpWorkshop;
 
 use Closure;
+use PhpSchool\PhpWorkshop\Patch\Transformer;
 
 /**
  * This class is responsible for storing the modifications that should
  * be made to a PHP file. That includes insertions and transformers.
  * A transformer is a simple closure which should receives an AST
  * representation of the student's solution and it should return the modified AST.
+ *
+ * Transformers can also be class implementing `Transformer`.
+ *
  * An insertion is a block of code that can be inserted at the top or bottom of
  * the students solution.
  */
 final class Patch
 {
     /**
-     * @var array<CodeInsertion|Closure>
+     * @var array<CodeInsertion|Closure|Transformer>
      */
     private $modifications = [];
 
@@ -35,12 +39,12 @@ final class Patch
     }
 
     /**
-     * Add a new transformer (`Closure`). `Patch` is immutable so a new instance is returned.
+     * Add a new transformer (`Closure` OR `Transformer`). `Patch` is immutable so a new instance is returned.
      *
-     * @param Closure $closure
+     * @param Closure|Transformer $closure
      * @return self
      */
-    public function withTransformer(Closure $closure): self
+    public function withTransformer($closure): self
     {
         $new = clone $this;
         $new->modifications[] = $closure;
@@ -48,9 +52,10 @@ final class Patch
     }
 
     /**
-     * Retrieve all the modifications including insertions (`CodeInsertion`'s) & transformers (`Closure`'s)
+     * Retrieve all the modifications including insertions (`CodeInsertion`'s)
+     * & transformers (`Closure`'s OR `Transformer`'s)
      *
-     * @return array<CodeInsertion|Closure>
+     * @return array<CodeInsertion|Closure|Transformer>
      */
     public function getModifiers(): array
     {

--- a/src/Patch/ForceStrictTypes.php
+++ b/src/Patch/ForceStrictTypes.php
@@ -3,15 +3,20 @@
 namespace PhpSchool\PhpWorkshop\Patch;
 
 use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\DeclareDeclare;
 
 class ForceStrictTypes implements Transformer
 {
-    public function transform(array $ast): array
+    /**
+     * @param array<Stmt> $statements
+     * @return array<Stmt>
+     */
+    public function transform(array $statements): array
     {
-        if ($this->isFirstStatementStrictTypesDeclare($ast)) {
-            return $ast;
+        if ($this->isFirstStatementStrictTypesDeclare($statements)) {
+            return $statements;
         }
 
         $declare = new \PhpParser\Node\Stmt\Declare_([
@@ -21,9 +26,12 @@ class ForceStrictTypes implements Transformer
             )
         ]);
 
-        return array_merge([$declare], $ast);
+        return array_merge([$declare], $statements);
     }
 
+    /**
+     * @param array<Stmt> $statements
+     */
     public function isFirstStatementStrictTypesDeclare(array $statements): bool
     {
         return isset($statements[0]) && $statements[0] instanceof Declare_;

--- a/src/Patch/ForceStrictTypes.php
+++ b/src/Patch/ForceStrictTypes.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Patch;
+
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\DeclareDeclare;
+
+class ForceStrictTypes implements Transformer
+{
+    public function transform(array $ast): array
+    {
+        if ($this->isFirstStatementStrictTypesDeclare($ast)) {
+            return $ast;
+        }
+
+        $declare = new \PhpParser\Node\Stmt\Declare_([
+            new DeclareDeclare(
+                new \PhpParser\Node\Identifier('strict_types'),
+                new LNumber(1)
+            )
+        ]);
+
+        return array_merge([$declare], $ast);
+    }
+
+    public function isFirstStatementStrictTypesDeclare(array $statements): bool
+    {
+        return isset($statements[0]) && $statements[0] instanceof Declare_;
+    }
+}

--- a/src/Patch/Transformer.php
+++ b/src/Patch/Transformer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Patch;
+
+interface Transformer
+{
+    public function transform(array $ast): array;
+}

--- a/src/Patch/Transformer.php
+++ b/src/Patch/Transformer.php
@@ -2,7 +2,13 @@
 
 namespace PhpSchool\PhpWorkshop\Patch;
 
+use PhpParser\Node\Stmt;
+
 interface Transformer
 {
-    public function transform(array $ast): array;
+    /**
+     * @param array<Stmt> $statements
+     * @return array<Stmt>
+     */
+    public function transform(array $statements): array;
 }

--- a/test/CodePatcherTest.php
+++ b/test/CodePatcherTest.php
@@ -95,7 +95,7 @@ class CodePatcherTest extends TestCase
                 (new Patch())->withInsertion(new Insertion(Insertion::TYPE_BEFORE, '    <?php $before = "here";')),
                 "<?php\n\n\$before = \"here\";\n\$original = true;"
             ],
-            'transformer' => [
+            'transformer-closure' => [
                 '<?php $original = true;',
                 (new Patch())
                     ->withTransformer(function (array $statements) {
@@ -121,6 +121,22 @@ class CodePatcherTest extends TestCase
                         ];
                     }),
                 "<?php\n\ntry {\n    \$before = \"here\";\n    \$original = true;\n} catch (Exception \$e) {\n}"
+            ],
+            'transformer-class' => [
+                '<?php $original = true;',
+                (new Patch())
+                    ->withTransformer(new class implements Patch\Transformer {
+                        public function transform(array $statements): array
+                        {
+                            return [
+                                new TryCatch(
+                                    $statements,
+                                    [new Catch_([new Name(\Exception::class)], new Variable('e'), [])]
+                                )
+                            ];
+                        }
+                    }),
+                "<?php\n\ntry {\n    \$original = true;\n} catch (Exception \$e) {\n}"
             ],
         ];
     }

--- a/test/Patch/ForceStrictTypesTest.php
+++ b/test/Patch/ForceStrictTypesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpSchool\PhpWorkshopTest\Patch;
+
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+use PhpSchool\PhpWorkshop\Patch\ForceStrictTypes;
+use PHPUnit\Framework\TestCase;
+
+class ForceStrictTypesTest extends TestCase
+{
+    public function testStrictTypesDeclareIsAppended(): void
+    {
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $ast = $parser->parse("<?php echo 'Hello World';");
+
+        $transformer = new ForceStrictTypes();
+        $ast = $transformer->transform($ast);
+
+        self::assertSame(
+            "declare (strict_types=1);\necho 'Hello World';",
+            (new Standard())->prettyPrint($ast)
+        );
+    }
+
+    public function testStrictTypesDeclareIsNotAppendedIfItAlreadyExists(): void
+    {
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $ast = $parser->parse("<?php declare (strict_types=1);\necho 'Hello World';");
+        $transformer = new ForceStrictTypes();
+
+        $ast = $transformer->transform($ast);
+
+        self::assertSame(
+            "declare (strict_types=1);\necho 'Hello World';",
+            (new Standard())->prettyPrint($ast)
+        );
+    }
+}

--- a/test/PatchTest.php
+++ b/test/PatchTest.php
@@ -19,7 +19,7 @@ class PatchTest extends TestCase
         $this->assertEquals([$insertion], $new->getModifiers());
     }
 
-    public function testWithTransformer(): void
+    public function testWithTransformerWithClosure(): void
     {
         $patch = new Patch();
         $transformer = function (array $statements) {
@@ -29,5 +29,43 @@ class PatchTest extends TestCase
         $this->assertNotSame($patch, $new);
         $this->assertEmpty($patch->getModifiers());
         $this->assertEquals([$transformer], $new->getModifiers());
+    }
+
+    public function testWithTransformerWithTransformer(): void
+    {
+        $patch = new Patch();
+        $transformer = new class implements Patch\Transformer {
+            public function transform(array $ast): array
+            {
+                return $ast;
+            }
+        };
+
+        $new = $patch->withTransformer($transformer);
+        $this->assertNotSame($patch, $new);
+        $this->assertEmpty($patch->getModifiers());
+        $this->assertEquals([$transformer], $new->getModifiers());
+    }
+
+    public function testWithTransformerMultiple(): void
+    {
+        $transformer1 = new class implements Patch\Transformer {
+            public function transform(array $ast): array
+            {
+                return $ast;
+            }
+        };
+        $transformer2 = function (array $statements) {
+            return $statements;
+        };
+
+        $patch = new Patch();
+        $new = $patch
+            ->withTransformer($transformer1)
+            ->withTransformer($transformer2);
+
+        $this->assertNotSame($patch, $new);
+        $this->assertEmpty($patch->getModifiers());
+        $this->assertEquals([$transformer1, $transformer2], $new->getModifiers());
     }
 }


### PR DESCRIPTION
Introduce a new way to define transformers as classes rather than closures.

Introduce a `ForceStrictTypes` patch which exercises can implement if they want.