### PR TITLE
Disable Xdebug when executing programs

### DIFF
--- a/src/ExerciseRunner/CgiRunner.php
+++ b/src/ExerciseRunner/CgiRunner.php
@@ -217,7 +217,8 @@ class CgiRunner implements ExerciseRunnerInterface
             'SCRIPT_FILENAME' => $fileName,
             'REDIRECT_STATUS' => 302,
             'QUERY_STRING'    => $request->getUri()->getQuery(),
-            'REQUEST_URI'     => $request->getUri()->getPath()
+            'REQUEST_URI'     => $request->getUri()->getPath(),
+            'XDEBUG_MODE'     => 'off',
         ];
 
         $cgi = sprintf('php-cgi%s', DIRECTORY_SEPARATOR === '\\' ? '.exe' : '');

--- a/src/ExerciseRunner/CliRunner.php
+++ b/src/ExerciseRunner/CliRunner.php
@@ -120,7 +120,7 @@ class CliRunner implements ExerciseRunnerInterface
         return new Process(
             $args->prepend($fileName)->prepend(PHP_BINARY)->getArrayCopy(),
             dirname($fileName),
-            null,
+            ['XDEBUG_MODE' => 'off'],
             null,
             10
         );


### PR DESCRIPTION
Xdebug overloads `var_dump` and adds extra info like the file & the line. This makes comparing student submission and the solution impossible since the output contains different file paths. Hence disabling it!

This will only work for Xdebug3, but that's all that supports PHP8 and I only need this for the PHP8 workshop.