### PR TITLE
Allow file comparisons to skip content regexes

### DIFF
--- a/src/ExerciseCheck/FileComparisonExerciseCheck.php
+++ b/src/ExerciseCheck/FileComparisonExerciseCheck.php
@@ -11,7 +11,7 @@ namespace PhpSchool\PhpWorkshop\ExerciseCheck;
 interface FileComparisonExerciseCheck
 {
     /**
-     * @return array<string>
+     * @return array<int|string, string|array{strip: string}>
      */
     public function getFilesToCompare(): array;
 }


### PR DESCRIPTION
This PR allows for file comparisons to strip out some content before comparing, based on a regex.


For example, I wanted this to strip out some time logs because they would be slightly different in both the reference & student solution. The content would still have to match the regex so everything is still being checked in a sense.