### PR TITLE
Better location of the php cli binary

### DIFF
--- a/src/Check/PhpLintCheck.php
+++ b/src/Check/PhpLintCheck.php
@@ -10,6 +10,7 @@ use PhpSchool\PhpWorkshop\Input\Input;
 use PhpSchool\PhpWorkshop\Result\ResultInterface;
 use PhpSchool\PhpWorkshop\Result\Success;
 use PhpSchool\PhpWorkshop\Result\Failure;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -35,14 +36,15 @@ class PhpLintCheck implements SimpleCheckInterface
      */
     public function check(ExerciseInterface $exercise, Input $input): ResultInterface
     {
-        $process = new Process([PHP_BINARY, '-l', $input->getArgument('program')]);
+        $finder = new ExecutableFinder();
+        $process = new Process([$finder->find('php'), '-l', $input->getArgument('program')]);
         $process->run();
 
         if ($process->isSuccessful()) {
             return Success::fromCheck($this);
         }
 
-        return Failure::fromCheckAndReason($this, trim($process->getErrorOutput()));
+        return Failure::fromCheckAndReason($this, trim($process->getErrorOutput()) ?: trim($process->getOutput()));
     }
 
     /**

--- a/src/ExerciseRunner/CgiRunner.php
+++ b/src/ExerciseRunner/CgiRunner.php
@@ -86,7 +86,7 @@ class CgiRunner implements ExerciseRunnerInterface
                 system(sprintf('%s --version %s', $newPath, $silence), $stillFailedToRun);
                 if ($stillFailedToRun) {
                     throw new RuntimeException(
-                        'Could not load php-cgi binary. Please install php-cgi using your package manager.'
+                        'Could not find php-cgi binary. Please install php-cgi using your package manager.'
                     );
                 }
             }
@@ -94,7 +94,7 @@ class CgiRunner implements ExerciseRunnerInterface
             @system('php-cgi --version > /dev/null 2>&1', $failedToRun);
             if ($failedToRun) {
                 throw new RuntimeException(
-                    'Could not load php-cgi binary. Please install php-cgi using your package manager.'
+                    'Could not find php-cgi binary. Please install php-cgi using your package manager.'
                 );
             }
         }

--- a/src/ExerciseRunner/CliRunner.php
+++ b/src/ExerciseRunner/CliRunner.php
@@ -25,6 +25,7 @@ use PhpSchool\PhpWorkshop\Result\Cli\Success;
 use PhpSchool\PhpWorkshop\Result\Cli\ResultInterface as CliResultInterface;
 use PhpSchool\PhpWorkshop\Result\ResultInterface;
 use PhpSchool\PhpWorkshop\Utils\ArrayObject;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -118,7 +119,7 @@ class CliRunner implements ExerciseRunnerInterface
     private function getPhpProcess(string $fileName, ArrayObject $args): Process
     {
         return new Process(
-            $args->prepend($fileName)->prepend(PHP_BINARY)->getArrayCopy(),
+            $args->prepend($fileName)->prepend((new ExecutableFinder())->find('php'))->getArrayCopy(),
             dirname($fileName),
             ['XDEBUG_MODE' => 'off'],
             null,


### PR DESCRIPTION
When running in a web context, via php-fpm, `PHP_BINARY` points to a different binary which doesn't support the same flags that we pass in these two instances.