### PR TITLE
Introduce exercise scenario objects

### DIFF
--- a/src/Exercise/Scenario/CgiScenario.php
+++ b/src/Exercise/Scenario/CgiScenario.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Exercise\Scenario;
+
+use Psr\Http\Message\RequestInterface;
+
+class CgiScenario extends ExerciseScenario
+{
+    /**
+     * @var array<RequestInterface>
+     */
+    private array $executions = [];
+
+    public function withExecution(RequestInterface $request): self
+    {
+        $this->executions[] = $request;
+
+        return $this;
+    }
+
+    /**
+     * @return array<RequestInterface>
+     */
+    public function getExecutions(): array
+    {
+        return $this->executions;
+    }
+}

--- a/src/Exercise/Scenario/CliScenario.php
+++ b/src/Exercise/Scenario/CliScenario.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Exercise\Scenario;
+
+use PhpSchool\PhpWorkshop\Utils\Collection;
+
+class CliScenario extends ExerciseScenario
+{
+    /**
+     * @var array<Collection<int, string>>
+     */
+    private array $executions = [];
+
+    /**
+     * @param array<string> $args
+     */
+    public function withExecution(array $args = []): static
+    {
+        $this->executions[] = new Collection($args);
+
+        return $this;
+    }
+
+    /**
+     * @return array<Collection<int, string>>
+     */
+    public function getExecutions(): array
+    {
+        return $this->executions;
+    }
+}

--- a/src/Exercise/Scenario/ExerciseScenario.php
+++ b/src/Exercise/Scenario/ExerciseScenario.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpSchool\PhpWorkshop\Exercise\Scenario;
+
+abstract class ExerciseScenario
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $files = [];
+
+    public function withFile(string $relativeFileName, string $content): static
+    {
+        $this->files[$relativeFileName] = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getFiles(): array
+    {
+        return $this->files;
+    }
+}

--- a/test/Exercise/Scenario/CgiScenarioTest.php
+++ b/test/Exercise/Scenario/CgiScenarioTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpSchool\PhpWorkshopTest\Exercise\Scenario;
+
+use PhpSchool\PhpWorkshop\Exercise\Scenario\CgiScenario;
+use PhpSchool\PhpWorkshop\Utils\Collection;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class CgiScenarioTest extends TestCase
+{
+    public function testScenario(): void
+    {
+        $requestOne = $this->createMock(RequestInterface::class);
+        $requestTwo = $this->createMock(RequestInterface::class);
+
+        $scenario = (new CgiScenario())
+            ->withFile('file1.txt', 'content1')
+            ->withFile('file2.txt', 'content2')
+            ->withExecution($requestOne)
+            ->withExecution($requestTwo);
+
+        static::assertEquals(
+            [
+                'file1.txt' => 'content1',
+                'file2.txt' => 'content2',
+            ],
+            $scenario->getFiles()
+        );
+
+        static::assertEquals(
+            [
+                $requestOne,
+                $requestTwo
+            ],
+            $scenario->getExecutions()
+        );
+    }
+}

--- a/test/Exercise/Scenario/CliScenarioTest.php
+++ b/test/Exercise/Scenario/CliScenarioTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpSchool\PhpWorkshopTest\Exercise\Scenario;
+
+use PhpSchool\PhpWorkshop\Exercise\Scenario\CliScenario;
+use PhpSchool\PhpWorkshop\Utils\Collection;
+use PHPUnit\Framework\TestCase;
+
+class CliScenarioTest extends TestCase
+{
+    public function testScenario(): void
+    {
+        $scenario = (new CliScenario())
+            ->withFile('file1.txt', 'content1')
+            ->withFile('file2.txt', 'content2')
+            ->withExecution(['arg1', 'arg2'])
+            ->withExecution(['arg3', 'arg4']);
+
+        static::assertEquals(
+            [
+                'file1.txt' => 'content1',
+                'file2.txt' => 'content2',
+            ],
+            $scenario->getFiles()
+        );
+
+        static::assertEquals(
+            [
+                ['arg1', 'arg2'],
+                ['arg3', 'arg4'],
+            ],
+            array_map(
+                fn (Collection $collection) => $collection->getArrayCopy(),
+                $scenario->getExecutions()
+            )
+        );
+    }
+}


### PR DESCRIPTION
Introduce DTO's which describe the exercise scenario. Will be used by exercises in the future instead of `getArgs()`, `getRequests()` etc.

We also can use it to define files which should be created in the execution directory.